### PR TITLE
Skip tag creation if it already exists

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -23,8 +23,18 @@ module.exports = async (pluginConfig, {branch, repositoryUrl}, {version, gitHead
   debug('release branch: %o', branch);
   const ref = `refs/tags/${gitTag}`;
 
-  debug('Create git tag %o with commit %o', ref, gitHead);
-  await github.gitdata.createReference({owner, repo, ref, sha: gitHead});
+  try {
+    // Test if the tag already exists
+    await github.gitdata.getReference({owner, repo, ref: `tags/${gitTag}`});
+  } catch (err) {
+    // If the error is 404, the tag doesn't exist, otherwise it's an error
+    if (err.code !== 404) {
+      throw err;
+    }
+    debug('Create git tag %o with commit %o', ref, gitHead);
+    await github.gitdata.createReference({owner, repo, ref, sha: gitHead});
+  }
+
   const {data: {id, html_url}} = await github.repos.createRelease(release); // eslint-disable-line camelcase
   logger.log('Published Github release: %s', html_url);
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -117,15 +117,17 @@ test.serial('Publish a release with an array of assets', async t => {
   const github = authenticate({githubToken})
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}})
+    .get(`/repos/${owner}/${repo}/git/refs/tags/${nextRelease.gitTag}`)
+    .reply(404)
+    .post(`/repos/${owner}/${repo}/git/refs`, {ref: `refs/tags/${nextRelease.gitTag}`, sha: nextRelease.gitHead})
+    .reply({})
     .post(`/repos/${owner}/${repo}/releases`, {
       tag_name: nextRelease.gitTag,
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
     })
-    .reply(200, {html_url: releaseUrl, id: releaseId})
-    .post(`/repos/${owner}/${repo}/git/refs`, {ref: `refs/tags/${nextRelease.gitTag}`, sha: nextRelease.gitHead})
-    .reply({});
+    .reply(200, {html_url: releaseUrl, id: releaseId});
 
   const githubUpload = upload({githubToken})
     .post(`/repos/${owner}/${repo}/releases/${releaseId}/assets?name=${escape('upload.txt')}`)
@@ -168,15 +170,17 @@ test.serial('Verify Github auth and release', async t => {
   const github = authenticate({githubToken: process.env.GH_TOKEN})
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}})
+    .get(`/repos/${owner}/${repo}/git/refs/tags/${nextRelease.gitTag}`)
+    .reply(404)
+    .post(`/repos/${owner}/${repo}/git/refs`, {ref: `refs/tags/${nextRelease.gitTag}`, sha: nextRelease.gitHead})
+    .reply({})
     .post(`/repos/${owner}/${repo}/releases`, {
       tag_name: nextRelease.gitTag,
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
     })
-    .reply(200, {html_url: releaseUrl, id: releaseId})
-    .post(`/repos/${owner}/${repo}/git/refs`, {ref: `refs/tags/${nextRelease.gitTag}`, sha: nextRelease.gitHead})
-    .reply({});
+    .reply(200, {html_url: releaseUrl, id: releaseId});
 
   const githubUpload = upload({githubToken: process.env.GH_TOKEN})
     .post(`/repos/${owner}/${repo}/releases/${releaseId}/assets?name=${escape('upload.txt')}`)


### PR DESCRIPTION
Do not create the tag if it has already been created by another plugin like `apm` or `git`.