### PR TITLE
Remove `githubToken` from options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # @semantic-release/github
 
-Set of [semantic-release](https://github.com/semantic-release/semantic-release) plugins for publishing a [Github release](https://help.github.com/articles/about-releases).
+Set of [semantic-release](https://github.com/semantic-release/semantic-release) plugins for publishing a
+[Github release](https://help.github.com/articles/about-releases).
 
 [![Travis](https://img.shields.io/travis/semantic-release/github.svg)](https://travis-ci.org/semantic-release/github)
 [![Codecov](https://img.shields.io/codecov/c/github/semantic-release/github.svg)](https://codecov.io/gh/semantic-release/github)
@@ -8,24 +9,27 @@ Set of [semantic-release](https://github.com/semantic-release/semantic-release) 
 
 ## verifyConditions
 
-Verify the presence and the validity of the `githubToken` (set via option or environment variable) and the `assets` option configuration.
+Verify the presence and the validity of the authentication (set via [environment variables](#environment-variables)) and
+the [assets](#assets) option configuration.
 
 ## publish
 
-Publish a [Github release](https://help.github.com/articles/about-releases), optionnaly uploading files.
+Publish a [Github release](https://help.github.com/articles/about-releases), optionally uploading files.
 
 ## Configuration
 
 ### Github Repository authentication
 
-The `Github` authentication configuration is **required** and can be set via [environment variables](#environment-variables).
+The `Github` authentication configuration is **required** and can be set via
+[environment variables](#environment-variables).
 
-Only the [personal token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) authentication is supported.
+Only the [personal token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)
+authentication is supported.
 
 ### Environment variables
 
 | Variable                       | Description                                               |
-| ------------------------------ | ----------------------------------------------------------|
+| ------------------------------ | --------------------------------------------------------- |
 | `GH_TOKEN` or `GITHUB_TOKEN`   | **Required.** The token used to authenticate with GitHub. |
 | `GH_URL` or `GITHUB_URL`       | The GitHub Enterprise endpoint.                           |
 | `GH_PREFIX` or `GITHUB_PREFIX` | The GitHub Enterprise API prefix.                         |
@@ -34,14 +38,14 @@ Only the [personal token](https://help.github.com/articles/creating-a-personal-a
 
 | Option                | Description                                                        | Default                                              |
 | --------------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
-| `githubToken`         | **Required.** The token used to authenticate with GitHub.          | `GH_TOKEN` or `GITHUB_TOKEN` environment variable.   |
 | `githubUrl`           | The GitHub Enterprise endpoint.                                    | `GH_URL` or `GITHUB_URL` environment variable.       |
 | `githubApiPathPrefix` | The GitHub Enterprise API prefix.                                  | `GH_PREFIX` or `GITHUB_PREFIX` environment variable. |
 | `assets`              | An array of files to upload to the release. See [assets](#assets). | -                                                    |
 
 #### `assets`
 
-Can be a [glob](https://github.com/isaacs/node-glob#glob-primer) or and `Array` of [globs](https://github.com/isaacs/node-glob#glob-primer) and `Object`s with the following properties
+Can be a [glob](https://github.com/isaacs/node-glob#glob-primer) or and `Array` of
+[globs](https://github.com/isaacs/node-glob#glob-primer) and `Object`s with the following properties
 
 | Property | Description                                                                                              | Default                              |
 | -------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------ |
@@ -49,7 +53,9 @@ Can be a [glob](https://github.com/isaacs/node-glob#glob-primer) or and `Array` 
 | `name`   | The name of the downloadable file on the Github release.                                                 | File name extracted from the `path`. |
 | `label`  | Short description of the file displayed on the Github release.                                           | -                                    |
 
-Each entry in the `assets` `Array` is globbed individually. A [glob](https://github.com/isaacs/node-glob#glob-primer) can be a `String` (`"dist/**/*.js"` or `"dist/mylib.js"`) or an `Array` of `String`s that will be globbed together (`["dist/**", "!**/*.css"]`).
+Each entry in the `assets` `Array` is globbed individually. A [glob](https://github.com/isaacs/node-glob#glob-primer)
+can be a `String` (`"dist/**/*.js"` or `"dist/mylib.js"`) or an `Array` of `String`s that will be globbed together
+(`["dist/**", "!**/*.css"]`).
 
 If a directory is configured, all the files under this directory and its children will be included.
 
@@ -59,15 +65,21 @@ Files can be included enven if they have a match in `.gitignore`.
 
 `'dist/*.js'`: include all the `js` files in the `dist` directory, but not in its sub-directories.
 
-`[['dist', '!**/*.css']]`: include all the files in the `dist` directory and its sub-directories excluding the `css` files.
+`[['dist', '!**/*.css']]`: include all the files in the `dist` directory and its sub-directories excluding the `css`
+files.
 
-`[{path: 'dist/MyLibrary.js', label: 'MyLibrary JS distribution'}, {path: 'dist/MyLibrary.css', label: 'MyLibrary CSS distribution'}]`: include the `dist/MyLibrary.js` and `dist/MyLibrary.css` files, and label them `MyLibrary JS distribution` and `MyLibrary CSS distribution` in the Github release.
+`[{path: 'dist/MyLibrary.js', label: 'MyLibrary JS distribution'}, {path: 'dist/MyLibrary.css', label: 'MyLibrary CSS
+distribution'}]`: include the `dist/MyLibrary.js` and `dist/MyLibrary.css` files, and label them `MyLibrary JS
+distribution` and `MyLibrary CSS distribution` in the Github release.
 
-`[['dist/**/*.{js,css}', '!**/*.min.*'], {path: 'build/MyLibrary.zip', label: 'MyLibrary'}]`: include all the `js` and `css` files in the `dist` directory and its sub-directories excluding the minified version, plus the `build/MyLibrary.zip` file and label it `MyLibrary` in the Github release.
+`[['dist/**/*.{js,css}', '!**/*.min.*'], {path: 'build/MyLibrary.zip', label: 'MyLibrary'}]`: include all the `js` and
+`css` files in the `dist` directory and its sub-directories excluding the minified version, plus the
+`build/MyLibrary.zip` file and label it `MyLibrary` in the Github release.
 
 ### Usage
 
-The plugins are used by default by [semantic-release](https://github.com/semantic-release/semantic-release) so no specific configuration is requiered if `githubToken`, `githubUrl` and `githubApiPathPrefix` are set via environment variable.
+The plugins are used by default by [semantic-release](https://github.com/semantic-release/semantic-release) so no
+specific configuration is required if `githubUrl` and `githubApiPathPrefix` are set via environment variable.
 
 Each individual plugin can be disabled, replaced or used with other plugins in the `package.json`:
 

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,7 +1,7 @@
 const {castArray} = require('lodash');
 
-module.exports = ({githubToken, githubUrl, githubApiPathPrefix, assets}) => ({
-  githubToken: githubToken || process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+module.exports = ({githubUrl, githubApiPathPrefix, assets}) => ({
+  githubToken: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
   githubUrl: githubUrl || process.env.GH_URL || process.env.GITHUB_URL,
   githubApiPathPrefix: githubApiPathPrefix || process.env.GH_PREFIX || process.env.GITHUB_PREFIX,
   assets: assets ? castArray(assets) : assets,

--- a/test/helpers/mock-github.js
+++ b/test/helpers/mock-github.js
@@ -3,15 +3,15 @@ import nock from 'nock';
 /**
  * Retun a `nock` object setup to respond to a github authentication request. Other expectation and responses can be chained.
  *
- * @param {String} [githubToken='GH_TOKEN'] The github token to return in the authentication response.
- * @param {String} [githubUrl='https://api.github.com'] The url on which to intercept http requests.
- * @param {String} [githubApiPathPrefix] The GitHub Enterprise API prefix.
+ * @param {String} [githubToken=process.env.GH_TOKEN || process.env.GITHUB_TOKEN || 'GH_TOKEN'] The github token to return in the authentication response.
+ * @param {String} [githubUrl=process.env.GH_URL || process.env.GITHUB_URL || 'https://api.github.com'] The url on which to intercept http requests.
+ * @param {String} [githubApiPathPrefix=process.env.GH_PREFIX || process.env.GITHUB_PREFIX || ''] The GitHub Enterprise API prefix.
  * @return {Object} A `nock` object ready to respond to a github authentication request.
  */
 export function authenticate({
-  githubToken = 'GH_TOKEN',
-  githubUrl = 'https://api.github.com',
-  githubApiPathPrefix = '',
+  githubToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || 'GH_TOKEN',
+  githubUrl = process.env.GH_URL || process.env.GITHUB_URL || 'https://api.github.com',
+  githubApiPathPrefix = process.env.GH_PREFIX || process.env.GITHUB_PREFIX || '',
 } = {}) {
   return nock(`${githubUrl}/${githubApiPathPrefix}`, {reqheaders: {Authorization: `token ${githubToken}`}});
 }
@@ -19,11 +19,16 @@ export function authenticate({
 /**
  * Retun a `nock` object setup to respond to a github release upload request. Other expectation and responses can be chained.
  *
- * @param {String} [githubToken='GH_TOKEN'] The github token to return in the authentication response.
+ * @param {String} [githubToken=process.env.GH_TOKEN || process.env.GITHUB_TOKEN || 'GH_TOKEN'] The github token to return in the authentication response.
  * @param {String} [uploadUrl] The url on which to intercept http requests.
  * @return {Object} A `nock` object ready to respond to a github file upload request.
  */
-export function upload({githubToken = 'GH_TOKEN', uploadUrl, contentType = 'text/plain', contentLength} = {}) {
+export function upload({
+  githubToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || 'GH_TOKEN',
+  uploadUrl,
+  contentType = 'text/plain',
+  contentLength,
+} = {}) {
   return nock(uploadUrl, {
     reqheaders: {Authorization: `token ${githubToken}`, 'content-type': contentType, 'content-length': contentLength},
   });

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -36,8 +36,8 @@ test.afterEach.always(() => {
 test.serial('Publish a release', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
-  const pluginConfig = {githubToken};
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
   const nextRelease = {version: '1.0.0', gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
@@ -45,7 +45,7 @@ test.serial('Publish a release', async t => {
   const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
 
-  const github = authenticate({githubToken})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}/git/refs/tags/${nextRelease.gitTag}`)
     .reply(404)
     .post(`/repos/${owner}/${repo}/git/refs`, {ref: `refs/tags/${nextRelease.gitTag}`, sha: nextRelease.gitHead})
@@ -67,8 +67,8 @@ test.serial('Publish a release', async t => {
 test.serial('Publish a release with an existing tag', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
-  const pluginConfig = {githubToken};
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
   const nextRelease = {version: '1.0.0', gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
@@ -76,7 +76,7 @@ test.serial('Publish a release with an existing tag', async t => {
   const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
 
-  const github = authenticate({githubToken})
+  const github = authenticate({})
     .get(`/repos/${owner}/${repo}/git/refs/tags/${nextRelease.gitTag}`)
     .reply({ref: `refs/tags/${nextRelease.gitTag}`, object: {sha: 'e23a1bd8d7240c1eb3287374956042ffbcadca84'}})
     .post(`/repos/${owner}/${repo}/releases`, {
@@ -108,7 +108,7 @@ test.serial('Publish a release with one asset', async t => {
   const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
 
-  const github = authenticate({githubToken: process.env.GH_TOKEN})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}/git/refs/tags/${nextRelease.gitTag}`)
     .reply(404)
     .post(`/repos/${owner}/${repo}/git/refs`, {ref: `refs/tags/${nextRelease.gitTag}`, sha: nextRelease.gitHead})
@@ -122,7 +122,6 @@ test.serial('Publish a release with one asset', async t => {
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
 
   const githubUpload = upload({
-    githubToken: process.env.GH_TOKEN,
     uploadUrl: 'https://github.com',
     contentLength: (await stat('test/fixtures/.dotfile')).size,
   })
@@ -160,7 +159,6 @@ test.serial('Publish a release with one asset and custom github url', async t =>
 
   const github = authenticate({
     githubUrl: process.env.GH_URL,
-    githubToken: process.env.GH_TOKEN,
     githubApiPathPrefix: process.env.GH_PREFIX,
   })
     .get(`/repos/${owner}/${repo}/git/refs/tags/${nextRelease.gitTag}`)
@@ -177,7 +175,6 @@ test.serial('Publish a release with one asset and custom github url', async t =>
 
   const githubUpload = upload({
     uploadUrl: process.env.GH_URL,
-    githubToken: process.env.GH_TOKEN,
     contentLength: (await stat('test/fixtures/upload.txt')).size,
   })
     .post(`${uploadUri}?name=${escape('upload.txt')}&label=${escape('A text file')}`)
@@ -194,12 +191,9 @@ test.serial('Publish a release with one asset and custom github url', async t =>
 test.serial('Publish a release with an array of missing assets', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
   const emptyDirectory = tempy.directory();
-  const pluginConfig = {
-    githubToken,
-    assets: [emptyDirectory, {path: 'test/fixtures/missing.txt', name: 'missing.txt'}],
-  };
+  const pluginConfig = {assets: [emptyDirectory, {path: 'test/fixtures/missing.txt', name: 'missing.txt'}]};
   const nextRelease = {version: '1.0.0', gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
@@ -207,7 +201,7 @@ test.serial('Publish a release with an array of missing assets', async t => {
   const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
 
-  const github = authenticate({githubToken})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}/git/refs/tags/${nextRelease.gitTag}`)
     .reply(404)
     .post(`/repos/${owner}/${repo}/git/refs`, {ref: `refs/tags/${nextRelease.gitTag}`, sha: nextRelease.gitHead})
@@ -234,12 +228,12 @@ test.serial('Publish a release with an array of missing assets', async t => {
 test.serial('Throw Error if get tag call return an error other than 404', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
-  const pluginConfig = {githubToken};
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
   const nextRelease = {version: '1.0.0', gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
 
-  const github = authenticate({githubToken})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}/git/refs/tags/${nextRelease.gitTag}`)
     .reply(500);
 

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -32,19 +32,14 @@ test.afterEach.always(() => {
 test.serial('Verify package, token and repository access', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
+  process.env.GH_TOKEN = 'github_token';
   const assets = [{path: 'lib/file.js'}, 'file.js'];
-
-  const github = authenticate({githubToken})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
   await t.notThrows(
-    verify(
-      {githubToken, assets},
-      {repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`},
-      t.context.logger
-    )
+    verify({assets}, {repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`}, t.context.logger)
   );
   t.true(github.isDone());
 });
@@ -52,21 +47,21 @@ test.serial('Verify package, token and repository access', async t => {
 test.serial('Verify package, token and repository access and custom URL', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
+  process.env.GH_TOKEN = 'github_token';
   const githubUrl = 'https://othertesturl.com:9090';
-  const githubToken = 'github_token';
   const githubApiPathPrefix = 'prefix';
-
-  const github = authenticate({githubUrl, githubToken, githubApiPathPrefix})
+  const github = authenticate({githubUrl, githubApiPathPrefix})
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
   await t.notThrows(
     verify(
-      {githubUrl, githubToken, githubApiPathPrefix},
+      {githubUrl, githubApiPathPrefix},
       {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`},
       t.context.logger
     )
   );
+
   t.true(github.isDone());
   t.deepEqual(t.context.log.args[0], ['Verify Github authentication (%s)', 'https://othertesturl.com:9090/prefix']);
 });
@@ -76,24 +71,15 @@ test.serial('Verify package, token and repository with environment variables', a
   const repo = 'test_repo';
   process.env.GH_URL = 'https://othertesturl.com:443';
   process.env.GH_TOKEN = 'github_token';
-
-  const github = authenticate({
-    githubUrl: process.env.GH_URL,
-    githubToken: process.env.GH_TOKEN,
-    githubApiPathPrefix: process.env.GH_PREFIX,
-  })
+  process.env.GH_PREFIX = 'prefix';
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(
-    verify(
-      {githubUrl: process.env.GH_URL, githubApiPathPrefix: process.env.GH_PREFIX},
-      {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`},
-      t.context.logger
-    )
-  );
+  await t.notThrows(verify({}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+
   t.true(github.isDone());
-  t.deepEqual(t.context.log.args[0], ['Verify Github authentication (%s)', 'https://othertesturl.com:443/']);
+  t.deepEqual(t.context.log.args[0], ['Verify Github authentication (%s)', 'https://othertesturl.com:443/prefix']);
 });
 
 test.serial('Verify package, token and repository access with alternative environment varialbes', async t => {
@@ -103,29 +89,20 @@ test.serial('Verify package, token and repository access with alternative enviro
   process.env.GITHUB_TOKEN = 'github_token';
   process.env.GITHUB_PREFIX = 'prefix';
 
-  const github = authenticate({
-    githubUrl: process.env.GITHUB_URL,
-    githubToken: process.env.GITHUB_TOKEN,
-    githubApiPathPrefix: process.env.GITHUB_PREFIX,
-  })
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(
-    verify(
-      {githubUrl: process.env.GITHUB_URL, githubApiPathPrefix: process.env.GITHUB_PREFIX},
-      {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`},
-      t.context.logger
-    )
-  );
+  await t.notThrows(verify({}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
   t.true(github.isDone());
 });
 
 test.serial('Throw SemanticReleaseError if "assets" option is not a String or an Array of Objects', async t => {
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
   const assets = 42;
+
   const error = await t.throws(
-    verify({githubToken, assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
+    verify({assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -133,10 +110,11 @@ test.serial('Throw SemanticReleaseError if "assets" option is not a String or an
 });
 
 test.serial('Throw SemanticReleaseError if "assets" option is an Array with invalid elements', async t => {
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
   const assets = ['file.js', 42];
+
   const error = await t.throws(
-    verify({githubToken, assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
+    verify({assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -146,88 +124,79 @@ test.serial('Throw SemanticReleaseError if "assets" option is an Array with inva
 test.serial('Verify "assets" is a String', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
   const assets = 'file2.js';
-
-  const github = authenticate({githubToken})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(
-    verify({githubToken, assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger)
-  );
+  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+
   t.true(github.isDone());
 });
 
 test.serial('Verify "assets" is an Object with a path property', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
   const assets = {path: 'file2.js'};
-
-  const github = authenticate({githubToken})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(
-    verify({githubToken, assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger)
-  );
+  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+
   t.true(github.isDone());
 });
 
 test.serial('Verify "assets" is an Array of Object with a path property', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
   const assets = [{path: 'file1.js'}, {path: 'file2.js'}];
-
-  const github = authenticate({githubToken})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(
-    verify({githubToken, assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger)
-  );
+  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+
   t.true(github.isDone());
 });
 
 test.serial('Verify "assets" is an Array of glob Arrays', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
   const assets = [['dist/**', '!**/*.js'], 'file2.js'];
-
-  const github = authenticate({githubToken})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(
-    verify({githubToken, assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger)
-  );
+  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+
   t.true(github.isDone());
 });
 
 test.serial('Verify "assets" is an Array of Object with a glob Arrays in path property', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
   const assets = [{path: ['dist/**', '!**/*.js']}, {path: 'file2.js'}];
-
-  const github = authenticate({githubToken})
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(
-    verify({githubToken, assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger)
-  );
+  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+
   t.true(github.isDone());
 });
 
 test.serial('Throw SemanticReleaseError if "assets" option is an Object missing the "path" property', async t => {
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
   const assets = {name: 'file.js'};
+
   const error = await t.throws(
-    verify({githubToken, assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
+    verify({assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -237,10 +206,11 @@ test.serial('Throw SemanticReleaseError if "assets" option is an Object missing 
 test.serial(
   'Throw SemanticReleaseError if "assets" option is an Array with objects missing the "path" property',
   async t => {
-    const githubToken = 'github_token';
+    process.env.GITHUB_TOKEN = 'github_token';
     const assets = [{path: 'lib/file.js'}, {name: 'file.js'}];
+
     const error = await t.throws(
-      verify({githubToken, assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
+      verify({assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
     );
 
     t.true(error instanceof SemanticReleaseError);
@@ -260,14 +230,13 @@ test.serial('Throw SemanticReleaseError for missing github token', async t => {
 test.serial('Throw SemanticReleaseError for invalid token', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
-
-  const github = authenticate({githubToken})
+  process.env.GITHUB_TOKEN = 'github_token';
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(401);
 
   const error = await t.throws(
-    verify({githubToken}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
+    verify({}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -276,9 +245,9 @@ test.serial('Throw SemanticReleaseError for invalid token', async t => {
 });
 
 test.serial('Throw SemanticReleaseError for invalid repositoryUrl', async t => {
-  const githubToken = 'github_token';
+  process.env.GITHUB_TOKEN = 'github_token';
 
-  const error = await t.throws(verify({githubToken}, {repositoryUrl: 'invalid_url'}, t.context.logger));
+  const error = await t.throws(verify({}, {repositoryUrl: 'invalid_url'}, t.context.logger));
 
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'EINVALIDGITURL');
@@ -287,14 +256,13 @@ test.serial('Throw SemanticReleaseError for invalid repositoryUrl', async t => {
 test.serial("Throw SemanticReleaseError if token doesn't have the push permission on the repository", async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
-
-  const github = authenticate({githubToken})
+  process.env.GITHUB_TOKEN = 'github_token';
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: false}});
 
   const error = await t.throws(
-    verify({githubToken}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
+    verify({}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -305,14 +273,13 @@ test.serial("Throw SemanticReleaseError if token doesn't have the push permissio
 test.serial("Throw SemanticReleaseError if the repository doesn't exist", async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
-
-  const github = authenticate({githubToken})
+  process.env.GITHUB_TOKEN = 'github_token';
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(404);
 
   const error = await t.throws(
-    verify({githubToken}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
+    verify({}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -323,14 +290,13 @@ test.serial("Throw SemanticReleaseError if the repository doesn't exist", async 
 test.serial('Throw error if github return any other errors', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  const githubToken = 'github_token';
-
-  const github = authenticate({githubToken})
+  process.env.GITHUB_TOKEN = 'github_token';
+  const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(500);
 
   const error = await t.throws(
-    verify({githubToken}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
+    verify({}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
   );
 
   t.is(error.code, 500);


### PR DESCRIPTION
Allowing to set the `githubToken` in the configuration is not particularly useful and create a security risk. If users sets it in their config locally and commit the change by mistake their token would be exposed.

To be safer, it's probably better to allow to configure the Github token only via environment variable.