### PR TITLE
Migrate to the new name of the github api client

### DIFF
--- a/lib/get-client.js
+++ b/lib/get-client.js
@@ -1,5 +1,5 @@
 const url = require('url');
-const GitHubApi = require('github');
+const GitHubApi = require('@octokit/rest');
 
 module.exports = (githubToken, githubUrl, githubApiPathPrefix) => {
   const {port, protocol, hostname} = githubUrl ? url.parse(githubUrl) : {};

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "Gregor Martynus (https://twitter.com/gr2m)"
   ],
   "dependencies": {
+    "@octokit/rest": "^14.0.3",
     "@semantic-release/error": "^2.1.0",
     "debug": "^3.1.0",
     "fs-extra": "^5.0.0",
-    "github": "^13.0.0",
     "globby": "^7.1.1",
     "lodash": "^4.17.4",
     "mime": "^2.0.3",


### PR DESCRIPTION
See https://github.com/octokit/rest.js/releases/tag/v14.0.0

This will avoid getting warnings when installing semantic-release.