### PR TITLE
Add success and fail plugin hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Publish a [GitHub release](https://help.github.com/articles/about-releases), opt
 
 ## success
 
-Add a comment to each GitHub issue or pull request resolved by the release.
+Add a comment to each GitHub issue or pull request resolved by the release and close issues previously open by the [fail](#fail) step.
+
+## fail
+
+Open or update a GitHub issue with informations about the errors that caused the release to fail.
 
 ## Configuration
 
@@ -42,12 +46,16 @@ Follow the [Creating a personal access token for the command line](https://help.
 
 ### Options
 
-| Option                | Description                                                                                                      | Default                                                                                                                                              |
-|-----------------------|------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `githubUrl`           | The GitHub Enterprise endpoint.                                                                                  | `GH_URL` or `GITHUB_URL` environment variable.                                                                                                       |
-| `githubApiPathPrefix` | The GitHub Enterprise API prefix.                                                                                | `GH_PREFIX` or `GITHUB_PREFIX` environment variable.                                                                                                 |
-| `assets`              | An array of files to upload to the release. See [assets](#assets).                                               | -                                                                                                                                                    |
-| `successComment`      | The comment added to each issue and pull request resolved by the release. See [successComment](#successcomment). | `:tada: This issue has been resolved in version ${nextRelease.version} :tada:\n\nThe release is available on [GitHub release](<github_release_url>)` |
+| Option                | Description                                                                                                                                                  | Default                                                                                                                                              |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `githubUrl`           | The GitHub Enterprise endpoint.                                                                                                                              | `GH_URL` or `GITHUB_URL` environment variable.                                                                                                       |
+| `githubApiPathPrefix` | The GitHub Enterprise API prefix.                                                                                                                            | `GH_PREFIX` or `GITHUB_PREFIX` environment variable.                                                                                                 |
+| `assets`              | An array of files to upload to the release. See [assets](#assets).                                                                                           | -                                                                                                                                                    |
+| `successComment`      | The comment added to each issue and pull request resolved by the release. See [successComment](#successcomment).                                             | `:tada: This issue has been resolved in version ${nextRelease.version} :tada:\n\nThe release is available on [GitHub release](<github_release_url>)` |
+| `failComment`         | The content of the issue created when a release fails. See [failComment](#failcomment).                                                                      | Friendly message with links to **semantic-release** documentation and support, with the list of errors that caused the release to fail.              |
+| `failTitle`           | The title of the issue created when a release fails.                                                                                                         | `The automated release is failing :rotating_light:`                                                                                                  |
+| `labels`              | The [labels](https://help.github.com/articles/about-labels) to add to the issue created when a release fails.                                                | `['semantic-release']`                                                                                                                               |
+| `assignees`           | The [assignees](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users) to add to the issue created when a release fails. | -                                                                                                                                                    |
 
 #### assets
 
@@ -102,6 +110,23 @@ The `successComment` `This ${issue.pull_request ? 'pull request' : 'issue'} is i
 
 > This pull request is included in version 1.0.0
 
+#### failComment
+
+The message for the issue content is generated with [Lodash template](https://lodash.com/docs#template). The following variables are available:
+
+| Parameter | Description                                                                                                                                                                                                                                                                                                             |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `branch`  | The branch from which the release had failed.                                                                                                                                                                                                                                                                           |
+| `errors`  | An `Array` of [SemanticReleaseError](https://github.com/semantic-release/error). Each error has the `message`, `code`, `pluginName` and `details` properties.<br>`pluginName` contains the package name of the plugin that threw the error.<br>`details` contains a informations about the error formatted in markdown. |
+
+##### failComment examples
+
+The `failComment` `This release from branch ${branch} had failed due to the following errors:\n- ${errors.map(err => err.message).join('\\n- ')}` will generate the comment:
+
+> This release from branch master had failed due to the following errors:
+> - Error message 1
+> - Error message 2
+
 ### Usage
 
 The plugins are used by default by [Semantic-release](https://github.com/semantic-release/semantic-release) so no
@@ -114,7 +139,8 @@ Each individual plugin can be disabled, replaced or used with other plugins in t
   "release": {
     "verifyConditions": ["@semantic-release/github", "@semantic-release/npm", "verify-other-condition"],
     "publish": ["@semantic-release/npm", "@semantic-release/github", "other-publish"],
-    "success": ["@semantic-release/github", "other-success"]
+    "success": ["@semantic-release/github", "other-success"],
+    "fail": ["@semantic-release/github", "other-fail"]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add a comment to each GitHub issue or pull request resolved by the release.
 The GitHub authentication configuration is **required** and can be set via
 [environment variables](#environment-variables).
 
-Follow the [Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) documentation to obtain an authentication token. The token has to be made available in your CI environment via the `GH_TOKEN` environment variable.
+Follow the [Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) documentation to obtain an authentication token. The token has to be made available in your CI environment via the `GH_TOKEN` environment variable. The user associated with the token must have push permission to the repository.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ the [assets](#assets) option configuration.
 
 Publish a [GitHub release](https://help.github.com/articles/about-releases), optionally uploading files.
 
+## success
+
+Add a comment to each GitHub issue or pull request resolved by the release.
+
 ## Configuration
 
 ### GitHub authentication
@@ -38,13 +42,14 @@ Follow the [Creating a personal access token for the command line](https://help.
 
 ### Options
 
-| Option                | Description                                                        | Default                                              |
-| --------------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
-| `githubUrl`           | The GitHub Enterprise endpoint.                                    | `GH_URL` or `GITHUB_URL` environment variable.       |
-| `githubApiPathPrefix` | The GitHub Enterprise API prefix.                                  | `GH_PREFIX` or `GITHUB_PREFIX` environment variable. |
-| `assets`              | An array of files to upload to the release. See [assets](#assets). | -                                                    |
+| Option                | Description                                                                                                      | Default                                                                                                                                              |
+|-----------------------|------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `githubUrl`           | The GitHub Enterprise endpoint.                                                                                  | `GH_URL` or `GITHUB_URL` environment variable.                                                                                                       |
+| `githubApiPathPrefix` | The GitHub Enterprise API prefix.                                                                                | `GH_PREFIX` or `GITHUB_PREFIX` environment variable.                                                                                                 |
+| `assets`              | An array of files to upload to the release. See [assets](#assets).                                               | -                                                                                                                                                    |
+| `successComment`      | The comment added to each issue and pull request resolved by the release. See [successComment](#successcomment). | `:tada: This issue has been resolved in version ${nextRelease.version} :tada:\n\nThe release is available on [GitHub release](<github_release_url>)` |
 
-#### `assets`
+#### assets
 
 Can be a [glob](https://github.com/isaacs/node-glob#glob-primer) or and `Array` of
 [globs](https://github.com/isaacs/node-glob#glob-primer) and `Object`s with the following properties
@@ -63,7 +68,7 @@ If a directory is configured, all the files under this directory and its childre
 
 Files can be included even if they have a match in `.gitignore`.
 
-##### `assets` examples
+##### assets examples
 
 `'dist/*.js'`: include all the `js` files in the `dist` directory, but not in its sub-directories.
 
@@ -78,6 +83,25 @@ distribution` and `MyLibrary CSS distribution` in the GitHub release.
 `css` files in the `dist` directory and its sub-directories excluding the minified version, plus the
 `build/MyLibrary.zip` file and label it `MyLibrary` in the GitHub release.
 
+#### successComment
+
+The message for the issue comments is generated with [Lodash template](https://lodash.com/docs#template). The following variables are available:
+
+| Parameter     | Description                                                                                                                                                                                                                                                                   |
+|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `branch`      | The branch from which the release is done.                                                                                                                                                                                                                                    |
+| `lastRelease` | `Object` with `version`, `gitTag` and `gitHead` of the last release.                                                                                                                                                                                                          |
+| `nextRelease` | `Object` with `version`, `gitTag`, `gitHead` and `notes` of the release being done.                                                                                                                                                                                           |
+| `commits`     | `Array` of commit `Object`s with `hash`, `subject`, `body` `message` and `author`.                                                                                                                                                                                            |
+| `releases`    | `Array` with a release `Object`s for each release published, with optional release data such has `name` and `url`.                                                                                                                                                            |
+| `issue`       | A [GitHub API pull request object](https://developer.github.com/v3/search/#search-issues) for pull requests related to a commit, or an `Object` with the `number` property for issues resolved via [keywords](https://help.github.com/articles/closing-issues-using-keywords) |
+
+##### successComment examples
+
+The `successComment` `This ${issue.pull_request ? 'pull request' : 'issue'} is included in version ${nextRelease.version}` will generate the comment:
+
+> This pull request is included in version 1.0.0
+
 ### Usage
 
 The plugins are used by default by [Semantic-release](https://github.com/semantic-release/semantic-release) so no
@@ -89,7 +113,8 @@ Each individual plugin can be disabled, replaced or used with other plugins in t
 {
   "release": {
     "verifyConditions": ["@semantic-release/github", "@semantic-release/npm", "verify-other-condition"],
-    "publish": ["@semantic-release/npm", "@semantic-release/github", "other-publish"]
+    "publish": ["@semantic-release/npm", "@semantic-release/github", "other-publish"],
+    "success": ["@semantic-release/github", "other-success"]
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const publishGitHub = require('./lib/publish');
 
 let verified;
 
-async function verifyConditions(pluginConfig, {options, logger}) {
+async function verifyConditions(pluginConfig, context) {
+  const {options} = context;
   // If the GitHub publish plugin is used and has `assets` configured, validate it now in order to prevent any release if the configuration is wrong
   if (options.publish) {
     const publishPlugin = (Array.isArray(options.publish) ? options.publish : [options.publish]).find(
@@ -14,16 +15,16 @@ async function verifyConditions(pluginConfig, {options, logger}) {
     }
   }
 
-  await verifyGitHub(pluginConfig, options, logger);
+  await verifyGitHub(pluginConfig, context);
   verified = true;
 }
 
-async function publish(pluginConfig, {nextRelease, options, logger}) {
+async function publish(pluginConfig, context) {
   if (!verified) {
-    await verifyGitHub(pluginConfig, options, logger);
+    await verifyGitHub(pluginConfig, context);
     verified = true;
   }
-  await publishGitHub(pluginConfig, options, nextRelease, logger);
+  await publishGitHub(pluginConfig, context);
 }
 
 module.exports = {verifyConditions, publish};

--- a/index.js
+++ b/index.js
@@ -1,22 +1,25 @@
 const verifyGitHub = require('./lib/verify');
 const publishGitHub = require('./lib/publish');
 const successGitHub = require('./lib/success');
+const failGitHub = require('./lib/fail');
 
 let verified;
 
 async function verifyConditions(pluginConfig, context) {
   const {options} = context;
-  // If the GitHub publish plugin is used and has `assets` configured, validate it now in order to prevent any release if the configuration is wrong
+  // If the GitHub publish plugin is used and has `assets`, `successComment`, `failComment`, `failTitle`, `labels` or `assignees` configured, validate it now in order to prevent any release if the configuration is wrong
   if (options.publish) {
-    const publishPlugin = (Array.isArray(options.publish) ? options.publish : [options.publish]).find(
-      config => config.path && config.path === '@semantic-release/github'
-    );
-    if (publishPlugin && publishPlugin.assets) {
-      pluginConfig.assets = publishPlugin.assets;
-    }
-    if (publishPlugin && publishPlugin.successComment) {
-      pluginConfig.successComment = publishPlugin.successComment;
-    }
+    const publishPlugin =
+      (Array.isArray(options.publish) ? options.publish : [options.publish]).find(
+        config => config.path && config.path === '@semantic-release/github'
+      ) || {};
+
+    pluginConfig.assets = pluginConfig.assets || publishPlugin.assets;
+    pluginConfig.successComment = pluginConfig.successComment || publishPlugin.successComment;
+    pluginConfig.failComment = pluginConfig.failComment || publishPlugin.failComment;
+    pluginConfig.failTitle = pluginConfig.failTitle || publishPlugin.failTitle;
+    pluginConfig.labels = pluginConfig.labels || publishPlugin.labels;
+    pluginConfig.assignees = pluginConfig.assignees || publishPlugin.assignees;
   }
 
   await verifyGitHub(pluginConfig, context);
@@ -39,4 +42,12 @@ async function success(pluginConfig, context) {
   await successGitHub(pluginConfig, context);
 }
 
-module.exports = {verifyConditions, publish, success};
+async function fail(pluginConfig, context) {
+  if (!verified) {
+    await verifyGitHub(pluginConfig, context);
+    verified = true;
+  }
+  await failGitHub(pluginConfig, context);
+}
+
+module.exports = {verifyConditions, publish, success, fail};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const verifyGitHub = require('./lib/verify');
 const publishGitHub = require('./lib/publish');
+const successGitHub = require('./lib/success');
 
 let verified;
 
@@ -12,6 +13,9 @@ async function verifyConditions(pluginConfig, context) {
     );
     if (publishPlugin && publishPlugin.assets) {
       pluginConfig.assets = publishPlugin.assets;
+    }
+    if (publishPlugin && publishPlugin.successComment) {
+      pluginConfig.successComment = publishPlugin.successComment;
     }
   }
 
@@ -27,4 +31,12 @@ async function publish(pluginConfig, context) {
   return publishGitHub(pluginConfig, context);
 }
 
-module.exports = {verifyConditions, publish};
+async function success(pluginConfig, context) {
+  if (!verified) {
+    await verifyGitHub(pluginConfig, context);
+    verified = true;
+  }
+  await successGitHub(pluginConfig, context);
+}
+
+module.exports = {verifyConditions, publish, success};

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ async function publish(pluginConfig, context) {
     await verifyGitHub(pluginConfig, context);
     verified = true;
   }
-  await publishGitHub(pluginConfig, context);
+  return publishGitHub(pluginConfig, context);
 }
 
 module.exports = {verifyConditions, publish};

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -24,6 +24,38 @@ Your configuration for the \`assets\` option is \`${stringify(assets)}\`.`,
 
 Your configuration for the \`successComment\` option is \`${stringify(successComment)}\`.`,
   }),
+  EINVALIDFAILTITLE: ({failTitle}) => ({
+    message: 'Invalid `failTitle` option.',
+    details: `The [failTitle option](${linkify(
+      'README.md#failtitle'
+    )}) option, if defined, must be a non empty \`String\`.
+
+Your configuration for the \`failTitle\` option is \`${stringify(failTitle)}\`.`,
+  }),
+  EINVALIDFAILCOMMENT: ({failComment}) => ({
+    message: 'Invalid `failComment` option.',
+    details: `The [failComment option](${linkify(
+      'README.md#failcomment'
+    )}) option, if defined, must be a non empty \`String\`.
+
+Your configuration for the \`failComment\` option is \`${stringify(failComment)}\`.`,
+  }),
+  EINVALIDLABELS: ({labels}) => ({
+    message: 'Invalid `labels` option.',
+    details: `The [labels option](${linkify(
+      'README.md#labels'
+    )}) option, if defined, must be an \`Array\` of non empty \`String\`.
+
+Your configuration for the \`labels\` option is \`${stringify(labels)}\`.`,
+  }),
+  EINVALIDASSIGNEES: ({assignees}) => ({
+    message: 'Invalid `assignees` option.',
+    details: `The [assignees option](${linkify(
+      'README.md#assignees'
+    )}) option must be an \`Array\` of non empty \`Strings\`.
+
+Your configuration for the \`assignees\` option is \`${stringify(assignees)}\`.`,
+  }),
   EINVALIDGITHUBURL: () => ({
     message: 'The git repository URL is not a valid GitHub URL.',
     details: `The **semantic-release** \`repositoryUrl\` option must a valid GitHub URL with the format \`<GitHub_or_GHE_URL>/<owner>/<repo>.git\`.

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -1,0 +1,67 @@
+const url = require('url');
+const {inspect} = require('util');
+const {isString} = require('lodash');
+const pkg = require('../../package.json');
+
+const homepage = url.format({...url.parse(pkg.homepage), ...{hash: null}});
+const stringify = obj => (isString(obj) ? obj : inspect(obj, {breakLength: Infinity, depth: 2, maxArrayLength: 5}));
+const linkify = file => `${homepage}/blob/master/${file}`;
+
+module.exports = {
+  EINVALIDASSETS: ({assets}) => ({
+    message: 'Invalid `assets` option.',
+    details: `The [assets option](${linkify(
+      'README.md#assets'
+    )}) option must be an \`Array\` of \`Strings\` or \`Objects\` with a \`path\` property.
+
+Your configuration for the \`assets\` option is \`${stringify(assets)}\`.`,
+  }),
+  EINVALIDSUCCESSCOMMENT: ({successComment}) => ({
+    message: 'Invalid `successComment` option.',
+    details: `The [successComment option](${linkify(
+      'README.md#successcomment'
+    )}) option, if defined, must be a non empty \`String\`.
+
+Your configuration for the \`successComment\` option is \`${stringify(successComment)}\`.`,
+  }),
+  EINVALIDGITHUBURL: () => ({
+    message: 'The git repository URL is not a valid GitHub URL.',
+    details: `The **semantic-release** \`repositoryUrl\` option must a valid GitHub URL with the format \`<GitHub_or_GHE_URL>/<owner>/<repo>.git\`.
+
+By default the \`repositoryUrl\` option is retrieved from the \`repository\` property of your \`package.json\` or the [git origin url](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes) of the repository cloned by your CI environment.`,
+  }),
+  EMISSINGREPO: ({owner, repo}) => ({
+    message: `The repository ${owner}/${repo} doesn't exist.`,
+    details: `The **semantic-release** \`repositoryUrl\` option must refer to your GitHub repository. The repository must be accessible with the [GitHub API](https://developer.github.com/v3).
+
+By default the \`repositoryUrl\` option is retrieved from the \`repository\` property of your \`package.json\` or the [git origin url](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes) of the repository cloned by your CI environment.
+
+If you are using [GitHub Enterprise](https://enterprise.github.com) please make sure to configure the \`githubUrl\` and \`githubApiPathPrefix\` [options](${linkify(
+      'README.md#options'
+    )}).`,
+  }),
+  EGHNOPERMISSION: ({owner, repo}) => ({
+    message: `The GitHub token doesn't allow to push on the repository ${owner}/${repo}.`,
+    details: `The user associated with the [GitHub token](${linkify(
+      'README.md#github-authentication'
+    )}) configured in the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable must allows to push to the repository ${owner}/${repo}.
+
+Please make sure the GitHub user associated with the token is an [owner](https://help.github.com/articles/permission-levels-for-a-user-account-repository/#owner-access-on-a-repository-owned-by-a-user-account) or a [collaborator](https://help.github.com/articles/permission-levels-for-a-user-account-repository/#collaborator-access-on-a-repository-owned-by-a-user-account) if the reposotory belong to a user account or has [write permissions](https://help.github.com/articles/managing-team-access-to-an-organization-repository) if the repository [belongs to an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization).`,
+  }),
+  EINVALIDGHTOKEN: ({owner, repo}) => ({
+    message: 'Invalid GitHub token.',
+    details: `The [GitHub token](${linkify(
+      'README.md#github-authentication'
+    )}) configured in the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable must be a valid [personnal token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) allowing to push to the repository ${owner}/${repo}.
+
+Please make sure to set the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable in your CI with the exact value of the GitHub personnal token.`,
+  }),
+  ENOGHTOKEN: ({owner, repo}) => ({
+    message: 'No GitHub token specified.',
+    details: `A [GitHub personnal token](${linkify(
+      'README.md#github-authentication'
+    )}) must be created and set in the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable on your CI environment.
+
+Please make sure to create a [GitHub personnal token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) and to set it in the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable on your CI environment. The token must allow to push to the repository ${owner}/${repo}.`,
+  }),
+};

--- a/lib/definitions/sr-issue-id.js
+++ b/lib/definitions/sr-issue-id.js
@@ -1,0 +1,1 @@
+module.exports = '<!-- semantic-release:github -->';

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -1,0 +1,31 @@
+const {template} = require('lodash');
+const parseGithubUrl = require('parse-github-url');
+const debug = require('debug')('semantic-release:github');
+const ISSUE_ID = require('./definitions/sr-issue-id');
+const resolveConfig = require('./resolve-config');
+const getClient = require('./get-client');
+const findSRIssues = require('./find-sr-issues');
+const getFailComment = require('./get-fail-comment');
+
+module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, errors, logger}) => {
+  const {githubToken, githubUrl, githubApiPathPrefix, failComment, failTitle, labels, assignees} = resolveConfig(
+    pluginConfig
+  );
+  const {name: repo, owner} = parseGithubUrl(repositoryUrl);
+  const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
+  const body = failComment ? template(failComment)({branch, errors}) : getFailComment(branch, errors);
+  const srIssue = (await findSRIssues(github, failTitle, owner, repo))[0];
+
+  if (srIssue) {
+    logger.log('Found existing semantic-release issue #%d.', srIssue.number);
+    const comment = {owner, repo, number: srIssue.number, body};
+    debug('create comment: %O', comment);
+    const {data: {html_url: url}} = await github.issues.createComment(comment);
+    logger.log('Added comment to issue #%d: %s.', srIssue.number, url);
+  } else {
+    const newIssue = {owner, repo, title: failTitle, body: `${body}\n\n${ISSUE_ID}`, labels, assignees};
+    debug('create issue: %O', newIssue);
+    const {data: {html_url: url, number}} = await github.issues.create(newIssue);
+    logger.log('Created issue #%d: %s.', number, url);
+  }
+};

--- a/lib/find-sr-issues.js
+++ b/lib/find-sr-issues.js
@@ -1,0 +1,9 @@
+const ISSUE_ID = require('./definitions/sr-issue-id');
+
+module.exports = async (github, title, owner, repo) => {
+  const {data: {items: issues}} = await github.search.issues({
+    q: `title:${title}+repo:${owner}/${repo}+type:issue+state:open`,
+  });
+
+  return issues.filter(issue => issue.body && issue.body.includes(ISSUE_ID));
+};

--- a/lib/get-error.js
+++ b/lib/get-error.js
@@ -1,0 +1,7 @@
+const SemanticReleaseError = require('@semantic-release/error');
+const ERROR_DEFINITIONS = require('./definitions/errors');
+
+module.exports = (code, ctx = {}) => {
+  const {message, details} = ERROR_DEFINITIONS[code](ctx);
+  return new SemanticReleaseError(message, code, details);
+};

--- a/lib/get-fail-comment.js
+++ b/lib/get-fail-comment.js
@@ -1,0 +1,44 @@
+const HOME_URL = 'https://github.com/semantic-release/semantic-release';
+const FAQ_URL = `${HOME_URL}/blob/caribou/docs/support/FAQ.md`;
+const GET_HELP_URL = `${HOME_URL}#get-help`;
+const USAGE_DOC_URL = `${HOME_URL}/blob/caribou/docs/usage/README.md`;
+const NEW_ISSUE_URL = `${HOME_URL}/issues/new`;
+
+const formatError = error => `### ${error.message}
+
+${error.details ||
+  `Unfortunatly this error doesn't have any additionnal information.${
+    error.pluginName
+      ? ` Feel free to kindly ask the author of the \`${error.pluginName}\` plugin to add more helpful informations.`
+      : ''
+  }`}`;
+
+module.exports = (
+  branch,
+  errors
+) => `## :rotating_light: The automated release from the \`${branch}\` branch failed. :rotating_light:
+
+I recommend you give this issue a high priority, so other packages depending on you could benefit from your bug fixes and new features.
+
+You can find below the list of errors reported by **semantic-release**. Each one of them has to be resolved in order to automatically publish your package. I’m sure you can resolve this 💪.
+
+Errors are usually caused by a misconfiguration or an authentication problem. With each error reported below you will find explanation and guidance to help you to resolve it.
+
+Once all the errors are resolved, **semantic-release** will release your package the next time you push a commit the \`${branch}\` branch. You can also manually restart the failed CI job that runs **semantic-release**.
+
+If you are not sure how to resolve this, here is some links that can help you:
+- [Usage documentation](${USAGE_DOC_URL})
+- [Frequently Asked Questions](${FAQ_URL})
+- [Support channels](${GET_HELP_URL})
+
+If those don’t help, or if this issue is reporting something you think isn’t right, you can always ask the humans behind **[semantic-release](${NEW_ISSUE_URL})**.
+
+---
+
+${errors.map(formatError).join('\n\n---\n\n')}
+
+---
+
+Good luck with your project ✨
+
+Your **[semantic-release](${HOME_URL})** bot :package::rocket:`;

--- a/lib/get-success-comment.js
+++ b/lib/get-success-comment.js
@@ -1,0 +1,18 @@
+const HOME_URL = 'https://github.com/semantic-release/semantic-release';
+const linkify = releaseInfo =>
+  `${releaseInfo.url ? `[${releaseInfo.name}](${releaseInfo.url})` : `\`${releaseInfo.name}\``}`;
+
+module.exports = (issue, releaseInfos, nextRelease) =>
+  `:tada: This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${
+    nextRelease.version
+  } :tada:${
+    releaseInfos.length > 0
+      ? `\n\nThe release is available on${
+          releaseInfos.length === 1
+            ? ` ${linkify(releaseInfos[0])}`
+            : `:\n${releaseInfos.map(releaseInfo => `- ${linkify(releaseInfo)}`).join('\n')}`
+        }`
+      : ''
+  }
+
+Your **[semantic-release](${HOME_URL})** bot :package::rocket:`;

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -9,7 +9,7 @@ const globAssets = require('./glob-assets.js');
 const resolveConfig = require('./resolve-config');
 const getClient = require('./get-client');
 
-module.exports = async (pluginConfig, {branch, repositoryUrl}, {version, gitHead, gitTag, notes}, logger) => {
+module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, nextRelease: {gitTag, notes}, logger}) => {
   const {githubToken, githubUrl, githubApiPathPrefix, assets} = resolveConfig(pluginConfig);
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
   const github = getClient(githubToken, githubUrl, githubApiPathPrefix);

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -20,8 +20,8 @@ module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, nextRel
   debug('release name: %o', gitTag);
   debug('release branch: %o', branch);
 
-  const {data: {html_url: htmlUrl, upload_url: uploadUrl}} = await github.repos.createRelease(release);
-  logger.log('Published GitHub release: %s', htmlUrl);
+  const {data: {html_url: url, upload_url: uploadUrl}} = await github.repos.createRelease(release);
+  logger.log('Published GitHub release: %s', url);
 
   if (assets && assets.length > 0) {
     const globbedAssets = await globAssets(assets);
@@ -64,4 +64,6 @@ module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, nextRel
       logger.log('Published file %s', downloadUrl);
     });
   }
+
+  return {url, name: 'GitHub release'};
 };

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,8 +1,9 @@
 const {castArray} = require('lodash');
 
-module.exports = ({githubUrl, githubApiPathPrefix, assets}) => ({
+module.exports = ({githubUrl, githubApiPathPrefix, assets, successComment}) => ({
   githubToken: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
   githubUrl: githubUrl || process.env.GH_URL || process.env.GITHUB_URL,
   githubApiPathPrefix: githubApiPathPrefix || process.env.GH_PREFIX || process.env.GITHUB_PREFIX || '',
   assets: assets ? castArray(assets) : assets,
+  successComment,
 });

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,9 +1,23 @@
-const {castArray} = require('lodash');
+const {isUndefined, castArray} = require('lodash');
 
-module.exports = ({githubUrl, githubApiPathPrefix, assets, successComment}) => ({
+module.exports = ({
+  githubUrl,
+  githubApiPathPrefix,
+  assets,
+  successComment,
+  failComment,
+  failTitle,
+  labels,
+  assignees,
+}) => ({
   githubToken: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
   githubUrl: githubUrl || process.env.GH_URL || process.env.GITHUB_URL,
   githubApiPathPrefix: githubApiPathPrefix || process.env.GH_PREFIX || process.env.GITHUB_PREFIX || '',
   assets: assets ? castArray(assets) : assets,
   successComment,
+  failComment,
+  failTitle:
+    isUndefined(failTitle) || failTitle === false ? 'The automated release is failing :rotating_light:' : failTitle,
+  labels: isUndefined(labels) ? ['semantic-release'] : labels === false ? [] : castArray(labels),
+  assignees: assignees ? castArray(assignees) : assignees,
 });

--- a/lib/success.js
+++ b/lib/success.js
@@ -7,12 +7,13 @@ const debug = require('debug')('semantic-release:github');
 const resolveConfig = require('./resolve-config');
 const getClient = require('./get-client');
 const getSuccessComment = require('./get-success-comment');
+const findSRIssues = require('./find-sr-issues');
 
 module.exports = async (
   pluginConfig,
   {options: {branch, repositoryUrl}, lastRelease, commits, nextRelease, releases, logger}
 ) => {
-  const {githubToken, githubUrl, githubApiPathPrefix, successComment} = resolveConfig(pluginConfig);
+  const {githubToken, githubUrl, githubApiPathPrefix, successComment, failTitle} = resolveConfig(pluginConfig);
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
   const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
   const releaseInfos = releases.filter(release => Boolean(release.name));
@@ -56,6 +57,25 @@ module.exports = async (
       // Don't throw right away and continue to update other issues
     }
   });
+
+  const srIssues = await findSRIssues(github, failTitle, owner, repo);
+
+  debug('found semantic-release issues: %O', srIssues);
+
+  await pReduce(srIssues, async (_, issue) => {
+    debug('close issue: %O', issue);
+    try {
+      const updateIssue = {owner, repo, number: issue.number, state: 'closed'};
+      debug('closing issue: %O', updateIssue);
+      const {data: {html_url: url}} = await github.issues.edit(updateIssue);
+      logger.log('Closed issue #%d: %s.', issue.number, url);
+    } catch (err) {
+      errors.push(err);
+      logger.error('Failed to close the issue #%d.', issue.number);
+      // Don't throw right away and continue to close other issues
+    }
+  });
+
   if (errors.length > 0) {
     throw new AggregateError(errors);
   }

--- a/lib/success.js
+++ b/lib/success.js
@@ -1,0 +1,62 @@
+const {uniqBy, template} = require('lodash');
+const parseGithubUrl = require('parse-github-url');
+const pReduce = require('p-reduce');
+const AggregateError = require('aggregate-error');
+const issueParser = require('issue-parser')('github');
+const debug = require('debug')('semantic-release:github');
+const resolveConfig = require('./resolve-config');
+const getClient = require('./get-client');
+const getSuccessComment = require('./get-success-comment');
+
+module.exports = async (
+  pluginConfig,
+  {options: {branch, repositoryUrl}, lastRelease, commits, nextRelease, releases, logger}
+) => {
+  const {githubToken, githubUrl, githubApiPathPrefix, successComment} = resolveConfig(pluginConfig);
+  const {name: repo, owner} = parseGithubUrl(repositoryUrl);
+  const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
+  const releaseInfos = releases.filter(release => Boolean(release.name));
+
+  // Search for PRs associated with any commit in the release
+  const {data: {items: prs}} = await github.search.issues({
+    q: `${commits.map(commit => commit.hash).join('+')}+repo:${owner}/${repo}+type:pr`,
+  });
+
+  debug('found pull requests: %O', prs.map(pr => pr.number));
+
+  // Parse the release commits message and PRs body to find resolved issues/PRs via comment keyworkds
+  const issues = uniqBy(
+    [...prs.map(pr => pr.body), ...commits.map(commit => commit.message)]
+      .reduce((issues, message) => {
+        return message
+          ? issues.concat(issueParser(message).actions.map(action => ({number: parseInt(action.issue, 10)})))
+          : issues;
+      }, [])
+      .filter(issue => !prs.find(pr => pr.number === issue.number)),
+    'number'
+  );
+
+  debug('found issues via comments: %O', issues);
+
+  const errors = [];
+
+  // Make requests serially to avoid hitting the rate limit (https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)
+  await pReduce([...prs, ...issues], async (_, issue) => {
+    const body = successComment
+      ? template(successComment)({branch, lastRelease, commits, nextRelease, releases, issue})
+      : getSuccessComment(issue, releaseInfos, nextRelease);
+    try {
+      const comment = {owner, repo, number: issue.number, body};
+      debug('create comment: %O', comment);
+      const {data: {html_url: url}} = await github.issues.createComment(comment);
+      logger.log('Added comment to issue #%d: %s', issue.number, url);
+    } catch (err) {
+      errors.push(err);
+      logger.error('Failed to add a comment to the issue #%d.', issue.number);
+      // Don't throw right away and continue to update other issues
+    }
+  });
+  if (errors.length > 0) {
+    throw new AggregateError(errors);
+  }
+};

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -11,7 +11,17 @@ const isStringOrStringArray = value => isNonEmptyString(value) || (isArray(value
 
 module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
   const errors = [];
-  const {githubToken, githubUrl, githubApiPathPrefix, assets, successComment} = resolveConfig(pluginConfig);
+  const {
+    githubToken,
+    githubUrl,
+    githubApiPathPrefix,
+    assets,
+    successComment,
+    failComment,
+    failTitle,
+    labels,
+    assignees,
+  } = resolveConfig(pluginConfig);
 
   if (
     !isUndefined(assets) &&
@@ -26,6 +36,30 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
 
   if (!isUndefined(successComment) && successComment !== false && !isNonEmptyString(successComment)) {
     errors.push(getError('EINVALIDSUCCESSCOMMENT', {successComment}));
+  }
+
+  if (!isUndefined(failTitle) && failTitle !== false && !isNonEmptyString(failTitle)) {
+    errors.push(getError('EINVALIDFAILTITLE', {failTitle}));
+  }
+
+  if (!isUndefined(failComment) && failComment !== false && !isNonEmptyString(failComment)) {
+    errors.push(getError('EINVALIDFAILCOMMENT', {failComment}));
+  }
+
+  if (
+    !isUndefined(labels) &&
+    labels !== false &&
+    !(isArray(labels) && labels.every(label => isStringOrStringArray(label)))
+  ) {
+    errors.push(getError('EINVALIDLABELS', {labels}));
+  }
+
+  if (
+    !isUndefined(assignees) &&
+    assignees !== false &&
+    !(isArray(assignees) && assignees.every(assignee => isStringOrStringArray(assignee)))
+  ) {
+    errors.push(getError('EINVALIDASSIGNEES', {assignees}));
   }
 
   if (githubUrl) {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -2,9 +2,9 @@ const {isString, isPlainObject, isUndefined, isArray} = require('lodash');
 const parseGithubUrl = require('parse-github-url');
 const urlJoin = require('url-join');
 const AggregateError = require('aggregate-error');
-const SemanticReleaseError = require('@semantic-release/error');
 const resolveConfig = require('./resolve-config');
 const getClient = require('./get-client');
+const getError = require('./get-error');
 
 const isNonEmptyString = value => isString(value) && value.trim();
 const isStringOrStringArray = value => isNonEmptyString(value) || (isArray(value) && value.every(isNonEmptyString));
@@ -21,21 +21,11 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
       assets.every(asset => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path)))
     )
   ) {
-    errors.push(
-      new SemanticReleaseError(
-        'The "assets" options must be an Array of Strings or Objects with a path property.',
-        'EINVALIDASSETS'
-      )
-    );
+    errors.push(getError('EINVALIDASSETS', {assets}));
   }
 
   if (!isUndefined(successComment) && successComment !== false && !isNonEmptyString(successComment)) {
-    errors.push(
-      new SemanticReleaseError(
-        'The "successComment" options, if defined, must be a non empty String.',
-        'EINVALIDSUCCESSCOMMENT'
-      )
-    );
+    errors.push(getError('EINVALIDSUCCESSCOMMENT', {successComment}));
   }
 
   if (githubUrl) {
@@ -46,7 +36,7 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
 
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
   if (!owner || !repo) {
-    errors.push(new SemanticReleaseError('The git repository URL is not a valid GitHub URL.', 'EINVALIDGITURL'));
+    errors.push(getError('EINVALIDGITHUBURL'));
   }
 
   if (githubToken) {
@@ -55,24 +45,19 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
     try {
       const {data: {permissions: {push}}} = await github.repos.get({repo, owner});
       if (!push) {
-        errors.push(
-          new SemanticReleaseError(
-            `The github token doesn't allow to push on the repository ${owner}/${repo}.`,
-            'EGHNOPERMISSION'
-          )
-        );
+        errors.push(getError('EGHNOPERMISSION', {owner, repo}));
       }
     } catch (err) {
       if (err.code === 401) {
-        errors.push(new SemanticReleaseError('Invalid GitHub token.', 'EINVALIDGHTOKEN'));
+        errors.push(getError('EINVALIDGHTOKEN', {owner, repo}));
       } else if (err.code === 404) {
-        errors.push(new SemanticReleaseError(`The repository ${owner}/${repo} doesn't exist.`, 'EMISSINGREPO'));
+        errors.push(getError('EMISSINGREPO', {owner, repo}));
       } else {
         throw err;
       }
     }
   } else {
-    errors.push(new SemanticReleaseError('No github token specified.', 'ENOGHTOKEN'));
+    errors.push(getError('ENOGHTOKEN', {owner, repo}));
   }
   if (errors.length > 0) {
     throw new AggregateError(errors);

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -5,8 +5,8 @@ const SemanticReleaseError = require('@semantic-release/error');
 const resolveConfig = require('./resolve-config');
 const getClient = require('./get-client');
 
-module.exports = async (pluginConfig, {repositoryUrl}, logger) => {
   const {githubToken, githubUrl, githubApiPathPrefix, assets} = resolveConfig(pluginConfig);
+module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
 
   if (!githubToken) {
     throw new SemanticReleaseError('No github token specified.', 'ENOGHTOKEN');

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,6 +1,7 @@
 const {isString, isPlainObject, isUndefined, isArray} = require('lodash');
 const parseGithubUrl = require('parse-github-url');
 const urlJoin = require('url-join');
+const AggregateError = require('aggregate-error');
 const SemanticReleaseError = require('@semantic-release/error');
 const resolveConfig = require('./resolve-config');
 const getClient = require('./get-client');
@@ -9,11 +10,8 @@ const isNonEmptyString = value => isString(value) && value.trim();
 const isStringOrStringArray = value => isNonEmptyString(value) || (isArray(value) && value.every(isNonEmptyString));
 
 module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
+  const errors = [];
   const {githubToken, githubUrl, githubApiPathPrefix, assets, successComment} = resolveConfig(pluginConfig);
-
-  if (!githubToken) {
-    throw new SemanticReleaseError('No github token specified.', 'ENOGHTOKEN');
-  }
 
   if (
     !isUndefined(assets) &&
@@ -23,21 +21,20 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
       assets.every(asset => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path)))
     )
   ) {
-    throw new SemanticReleaseError(
-      'The "assets" options must be an Array of Strings or Objects with a path property.',
-      'EINVALIDASSETS'
+    errors.push(
+      new SemanticReleaseError(
+        'The "assets" options must be an Array of Strings or Objects with a path property.',
+        'EINVALIDASSETS'
+      )
     );
   }
 
-  const {name: repo, owner} = parseGithubUrl(repositoryUrl);
-  if (!owner || !repo) {
-    throw new SemanticReleaseError(`The git repository URL is not a valid GitHub URL.`, 'EINVALIDGITURL');
-  }
-
   if (!isUndefined(successComment) && successComment !== false && !isNonEmptyString(successComment)) {
-    throw new SemanticReleaseError(
-      'The "successComment" options, if defined, must be a non empty String.',
-      'EINVALIDSUCCESSCOMMENT'
+    errors.push(
+      new SemanticReleaseError(
+        'The "successComment" options, if defined, must be a non empty String.',
+        'EINVALIDSUCCESSCOMMENT'
+      )
     );
   }
 
@@ -47,23 +44,37 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
     logger.log('Verify GitHub authentication');
   }
 
-  const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
-  let push;
-
-  try {
-    ({data: {permissions: {push}}} = await github.repos.get({repo, owner}));
-  } catch (err) {
-    if (err.code === 401) {
-      throw new SemanticReleaseError('Invalid GitHub token.', 'EINVALIDGHTOKEN');
-    } else if (err.code === 404) {
-      throw new SemanticReleaseError(`The repository ${owner}/${repo} doesn't exist.`, 'EMISSINGREPO');
-    }
-    throw err;
+  const {name: repo, owner} = parseGithubUrl(repositoryUrl);
+  if (!owner || !repo) {
+    errors.push(new SemanticReleaseError('The git repository URL is not a valid GitHub URL.', 'EINVALIDGITURL'));
   }
-  if (!push) {
-    throw new SemanticReleaseError(
-      `The github token doesn't allow to push on the repository ${owner}/${repo}.`,
-      'EGHNOPERMISSION'
-    );
+
+  if (githubToken) {
+    const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
+
+    try {
+      const {data: {permissions: {push}}} = await github.repos.get({repo, owner});
+      if (!push) {
+        errors.push(
+          new SemanticReleaseError(
+            `The github token doesn't allow to push on the repository ${owner}/${repo}.`,
+            'EGHNOPERMISSION'
+          )
+        );
+      }
+    } catch (err) {
+      if (err.code === 401) {
+        errors.push(new SemanticReleaseError('Invalid GitHub token.', 'EINVALIDGHTOKEN'));
+      } else if (err.code === 404) {
+        errors.push(new SemanticReleaseError(`The repository ${owner}/${repo} doesn't exist.`, 'EMISSINGREPO'));
+      } else {
+        throw err;
+      }
+    }
+  } else {
+    errors.push(new SemanticReleaseError('No github token specified.', 'ENOGHTOKEN'));
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors);
   }
 };

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -5,8 +5,11 @@ const SemanticReleaseError = require('@semantic-release/error');
 const resolveConfig = require('./resolve-config');
 const getClient = require('./get-client');
 
-  const {githubToken, githubUrl, githubApiPathPrefix, assets} = resolveConfig(pluginConfig);
+const isNonEmptyString = value => isString(value) && value.trim();
+const isStringOrStringArray = value => isNonEmptyString(value) || (isArray(value) && value.every(isNonEmptyString));
+
 module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
+  const {githubToken, githubUrl, githubApiPathPrefix, assets, successComment} = resolveConfig(pluginConfig);
 
   if (!githubToken) {
     throw new SemanticReleaseError('No github token specified.', 'ENOGHTOKEN');
@@ -29,6 +32,13 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
   if (!owner || !repo) {
     throw new SemanticReleaseError(`The git repository URL is not a valid GitHub URL.`, 'EINVALIDGITURL');
+  }
+
+  if (!isUndefined(successComment) && successComment !== false && !isNonEmptyString(successComment)) {
+    throw new SemanticReleaseError(
+      'The "successComment" options, if defined, must be a non empty String.',
+      'EINVALIDSUCCESSCOMMENT'
+    );
   }
 
   if (githubUrl) {
@@ -57,7 +67,3 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
     );
   }
 };
-
-function isStringOrStringArray(value) {
-  return isString(value) || (isArray(value) && value.every(isString));
-}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "@octokit/rest": "^14.0.9",
-    "@semantic-release/error": "^2.1.0",
+    "@semantic-release/error": "^2.2.0",
     "aggregate-error": "^1.0.0",
     "debug": "^3.1.0",
     "fs-extra": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@octokit/rest": "^14.0.9",
     "@semantic-release/error": "^2.1.0",
+    "aggregate-error": "^1.0.0",
     "debug": "^3.1.0",
     "fs-extra": "^5.0.0",
     "globby": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "Gregor Martynus (https://twitter.com/gr2m)"
   ],
   "dependencies": {
-    "@octokit/rest": "^14.0.3",
+    "@octokit/rest": "^14.0.9",
     "@semantic-release/error": "^2.1.0",
     "debug": "^3.1.0",
     "fs-extra": "^5.0.0",
     "globby": "^7.1.1",
+    "issue-parser": "^1.0.1",
     "lodash": "^4.17.4",
     "mime": "^2.0.3",
     "p-reduce": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,10 @@
   "keywords": [
     "git",
     "github",
+    "issue",
+    "notifications",
     "publish",
+    "pull-request",
     "release",
     "semantic-release",
     "version"

--- a/test/fail.test.js
+++ b/test/fail.test.js
@@ -1,0 +1,200 @@
+import {escape} from 'querystring';
+import test from 'ava';
+import nock from 'nock';
+import {stub} from 'sinon';
+import SemanticReleaseError from '@semantic-release/error';
+import ISSUE_ID from '../lib/definitions/sr-issue-id';
+import fail from '../lib/fail';
+import {authenticate} from './helpers/mock-github';
+
+/* eslint camelcase: ["error", {properties: "never"}] */
+
+// Save the current process.env
+const envBackup = Object.assign({}, process.env);
+
+test.beforeEach(t => {
+  // Delete env variables in case they are on the machine running the tests
+  delete process.env.GH_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_URL;
+  delete process.env.GITHUB_URL;
+  delete process.env.GH_PREFIX;
+  delete process.env.GITHUB_PREFIX;
+  // Mock logger
+  t.context.log = stub();
+  t.context.error = stub();
+  t.context.logger = {log: t.context.log, error: t.context.error};
+});
+
+test.afterEach.always(() => {
+  // Restore process.env
+  process.env = envBackup;
+  // Clear nock
+  nock.cleanAll();
+});
+
+test.serial('Open a new issue with the list of errors', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'The automated release is failing :rotating_light:';
+  const pluginConfig = {failTitle};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const errors = [
+    new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
+    new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
+    new SemanticReleaseError('Error message 3', 'ERR3', 'Error 3 details'),
+  ];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
+    )
+    .reply(200, {items: []})
+    .post(`/repos/${owner}/${repo}/issues`, {
+      title: failTitle,
+      body: /---\n\n### Error message 1\n\nError 1 details\n\n---\n\n### Error message 2\n\nError 2 details\n\n---\n\n### Error message 3\n\nError 3 details\n\n---/,
+      labels: ['semantic-release'],
+    })
+    .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
+
+  await fail(pluginConfig, {options, errors, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(github.isDone());
+});
+
+test.serial('Open a new issue with the list of errors and custom title and comment', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'Custom title';
+  const failComment = `branch \${branch} \${errors[0].message} \${errors[1].message} \${errors[2].message}`;
+  const pluginConfig = {failTitle, failComment};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const errors = [
+    new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
+    new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
+    new SemanticReleaseError('Error message 3', 'ERR3', 'Error 3 details'),
+  ];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
+    )
+    .reply(200, {items: []})
+    .post(`/repos/${owner}/${repo}/issues`, {
+      title: failTitle,
+      body: `branch master Error message 1 Error message 2 Error message 3\n\n${ISSUE_ID}`,
+      labels: ['semantic-release'],
+    })
+    .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
+
+  await fail(pluginConfig, {options, errors, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(github.isDone());
+});
+
+test.serial('Open a new issue with assignees and the list of errors', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'The automated release is failing :rotating_light:';
+  const assignees = ['user1', 'user2'];
+  const pluginConfig = {failTitle, assignees};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const errors = [
+    new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
+    new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
+  ];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
+    )
+    .reply(200, {items: []})
+    .post(`/repos/${owner}/${repo}/issues`, {
+      title: failTitle,
+      body: /---\n\n### Error message 1\n\nError 1 details\n\n---\n\n### Error message 2\n\nError 2 details\n\n---/,
+      labels: ['semantic-release'],
+      assignees: ['user1', 'user2'],
+    })
+    .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
+
+  await fail(pluginConfig, {options, errors, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(github.isDone());
+});
+
+test.serial('Open a new issue without labels and the list of errors', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'The automated release is failing :rotating_light:';
+  const labels = false;
+  const pluginConfig = {failTitle, labels};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const errors = [
+    new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
+    new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
+  ];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
+    )
+    .reply(200, {items: []})
+    .post(`/repos/${owner}/${repo}/issues`, {
+      title: failTitle,
+      body: /---\n\n### Error message 1\n\nError 1 details\n\n---\n\n### Error message 2\n\nError 2 details\n\n---/,
+      labels: [],
+    })
+    .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
+
+  await fail(pluginConfig, {options, errors, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(github.isDone());
+});
+
+test.serial('Update the first existing issue with the list of errors', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'The automated release is failing :rotating_light:';
+  const pluginConfig = {failTitle};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const errors = [
+    new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
+    new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
+    new SemanticReleaseError('Error message 3', 'ERR3', 'Error 3 details'),
+  ];
+  const issues = [
+    {number: 1, body: 'Issue 1 body', title: failTitle},
+    {number: 2, body: `Issue 2 body\n\n${ISSUE_ID}`, title: failTitle},
+    {number: 3, body: `Issue 3 body\n\n${ISSUE_ID}`, title: failTitle},
+  ];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
+    )
+    .reply(200, {items: issues})
+    .post(`/repos/${owner}/${repo}/issues/2/comments`, {
+      body: /---\n\n### Error message 1\n\nError 1 details\n\n---\n\n### Error message 2\n\nError 2 details\n\n---\n\n### Error message 3\n\nError 3 details\n\n---/,
+    })
+    .reply(200, {html_url: 'https://github.com/issues/2', number: 2});
+
+  await fail(pluginConfig, {options, errors, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args[0], ['Found existing semantic-release issue #%d.', 2]);
+  t.deepEqual(t.context.log.args[1], ['Added comment to issue #%d: %s.', 2, 'https://github.com/issues/2']);
+  t.true(github.isDone());
+});

--- a/test/find-sr-issue.test.js
+++ b/test/find-sr-issue.test.js
@@ -1,0 +1,104 @@
+import {escape} from 'querystring';
+import test from 'ava';
+import nock from 'nock';
+import {stub} from 'sinon';
+import ISSUE_ID from '../lib/definitions/sr-issue-id';
+import findSRIssues from '../lib/find-sr-issues';
+import getClient from '../lib/get-client';
+import {authenticate} from './helpers/mock-github';
+
+/* eslint camelcase: ["error", {properties: "never"}] */
+
+// Save the current process.env
+const envBackup = Object.assign({}, process.env);
+
+test.beforeEach(t => {
+  // Delete env variables in case they are on the machine running the tests
+  delete process.env.GH_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_URL;
+  delete process.env.GITHUB_URL;
+  delete process.env.GH_PREFIX;
+  delete process.env.GITHUB_PREFIX;
+  // Mock logger
+  t.context.log = stub();
+  t.context.error = stub();
+  t.context.logger = {log: t.context.log, error: t.context.error};
+});
+
+test.afterEach.always(() => {
+  // Restore process.env
+  process.env = envBackup;
+  // Clear nock
+  nock.cleanAll();
+});
+
+test.serial('Filter out issues without ID', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const title = 'The automated release is failing :rotating_light:';
+  const issues = [
+    {number: 1, body: 'Issue 1 body', title},
+    {number: 2, body: `Issue 2 body\n\n${ISSUE_ID}`, title},
+    {number: 3, body: `Issue 3 body\n\n${ISSUE_ID}`, title},
+  ];
+  const github = authenticate({githubToken})
+    .get(
+      `/search/issues?q=${escape(`title:${title}`)}+${escape(`repo:${owner}/${repo}`)}+${escape('type:issue')}+${escape(
+        'state:open'
+      )}`
+    )
+    .reply(200, {items: issues});
+
+  const srIssues = await findSRIssues(getClient(githubToken), title, owner, repo);
+
+  t.deepEqual(srIssues, [
+    {number: 2, body: 'Issue 2 body\n\n<!-- semantic-release:github -->', title},
+    {number: 3, body: 'Issue 3 body\n\n<!-- semantic-release:github -->', title},
+  ]);
+
+  t.true(github.isDone());
+});
+
+test.serial('Return empty array if not issues found', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const title = 'The automated release is failing :rotating_light:';
+  const issues = [];
+  const github = authenticate({githubToken})
+    .get(
+      `/search/issues?q=${escape(`title:${title}`)}+${escape(`repo:${owner}/${repo}`)}+${escape('type:issue')}+${escape(
+        'state:open'
+      )}`
+    )
+    .reply(200, {items: issues});
+
+  const srIssues = await findSRIssues(getClient(githubToken), title, owner, repo);
+
+  t.deepEqual(srIssues, []);
+
+  t.true(github.isDone());
+});
+
+test.serial('Return empty array if not issues has matching ID', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const title = 'The automated release is failing :rotating_light:';
+  const issues = [{number: 1, body: 'Issue 1 body', title}, {number: 2, body: 'Issue 2 body', title}];
+  const github = authenticate({githubToken})
+    .get(
+      `/search/issues?q=${escape(`title:${title}`)}+${escape(`repo:${owner}/${repo}`)}+${escape('type:issue')}+${escape(
+        'state:open'
+      )}`
+    )
+    .reply(200, {items: issues});
+
+  const srIssues = await findSRIssues(getClient(githubToken), title, owner, repo);
+
+  t.deepEqual(srIssues, []);
+
+  t.true(github.isDone());
+});

--- a/test/get-fail-comment.test.js
+++ b/test/get-fail-comment.test.js
@@ -1,0 +1,51 @@
+import test from 'ava';
+import SemanticReleaseError from '@semantic-release/error';
+import getfailComment from '../lib/get-fail-comment';
+
+test('Comment with mutiple errors', t => {
+  const errors = [
+    new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
+    new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
+    new SemanticReleaseError('Error message 3', 'ERR3', 'Error 3 details'),
+  ];
+  const comment = getfailComment('master', errors);
+
+  t.regex(comment, /the `master` branch/);
+  t.regex(
+    comment,
+    /---\n\n### Error message 1\n\nError 1 details\n\n---\n\n### Error message 2\n\nError 2 details\n\n---\n\n### Error message 3\n\nError 3 details\n\n---/
+  );
+});
+
+test('Comment with one error', t => {
+  const errors = [new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details')];
+  const comment = getfailComment('master', errors);
+
+  t.regex(comment, /the `master` branch/);
+  t.regex(comment, /---\n\n### Error message 1\n\nError 1 details\n\n---/);
+});
+
+test('Comment with missing error details and pluginName', t => {
+  const error = new SemanticReleaseError('Error message 1', 'ERR1');
+  error.pluginName = 'some-plugin';
+  const errors = [error];
+  const comment = getfailComment('master', errors);
+
+  t.regex(comment, /the `master` branch/);
+  t.regex(
+    comment,
+    /---\n\n### Error message 1\n\nUnfortunatly this error doesn't have any additionnal information. Feel free to kindly ask the author of the `some-plugin` plugin to add more helpful informations.\n\n---/
+  );
+});
+
+test('Comment with missing error details and no pluginName', t => {
+  const error = new SemanticReleaseError('Error message 1', 'ERR1');
+  const errors = [error];
+  const comment = getfailComment('master', errors);
+
+  t.regex(comment, /the `master` branch/);
+  t.regex(
+    comment,
+    /---\n\n### Error message 1\n\nUnfortunatly this error doesn't have any additionnal information.\n\n---/
+  );
+});

--- a/test/get-success-comment.test.js
+++ b/test/get-success-comment.test.js
@@ -1,0 +1,94 @@
+import test from 'ava';
+import getSuccessComment from '../lib/get-success-comment';
+
+const HOME_URL = 'https://github.com/semantic-release/semantic-release';
+
+test('Comment for issue with multiple releases', t => {
+  const issue = {number: 1};
+  const releaseInfos = [
+    {name: 'GitHub release', url: 'https://github.com/release'},
+    {name: 'npm release', url: 'https://npm.com/release'},
+  ];
+  const nextRelease = {version: '1.0.0'};
+  const comment = getSuccessComment(issue, releaseInfos, nextRelease);
+
+  t.is(
+    comment,
+    `:tada: This issue has been resolved in version 1.0.0 :tada:
+
+The release is available on:
+- [GitHub release](https://github.com/release)
+- [npm release](https://npm.com/release)
+
+Your **[semantic-release](${HOME_URL})** bot :package::rocket:`
+  );
+});
+
+test('Comment for PR with multiple releases', t => {
+  const issue = {number: 1, pull_request: {}}; // eslint-disable-line camelcase
+  const releaseInfos = [
+    {name: 'GitHub release', url: 'https://github.com/release'},
+    {name: 'npm release', url: 'https://npm.com/release'},
+  ];
+  const nextRelease = {version: '1.0.0'};
+  const comment = getSuccessComment(issue, releaseInfos, nextRelease);
+
+  t.is(
+    comment,
+    `:tada: This PR is included in version 1.0.0 :tada:
+
+The release is available on:
+- [GitHub release](https://github.com/release)
+- [npm release](https://npm.com/release)
+
+Your **[semantic-release](${HOME_URL})** bot :package::rocket:`
+  );
+});
+
+test('Comment with missing release URL', t => {
+  const issue = {number: 1};
+  const releaseInfos = [{name: 'GitHub release', url: 'https://github.com/release'}, {name: 'npm release'}];
+  const nextRelease = {version: '1.0.0'};
+  const comment = getSuccessComment(issue, releaseInfos, nextRelease);
+
+  t.is(
+    comment,
+    `:tada: This issue has been resolved in version 1.0.0 :tada:
+
+The release is available on:
+- [GitHub release](https://github.com/release)
+- \`npm release\`
+
+Your **[semantic-release](${HOME_URL})** bot :package::rocket:`
+  );
+});
+
+test('Comment with one release', t => {
+  const issue = {number: 1};
+  const releaseInfos = [{name: 'GitHub release', url: 'https://github.com/release'}];
+  const nextRelease = {version: '1.0.0'};
+  const comment = getSuccessComment(issue, releaseInfos, nextRelease);
+
+  t.is(
+    comment,
+    `:tada: This issue has been resolved in version 1.0.0 :tada:
+
+The release is available on [GitHub release](https://github.com/release)
+
+Your **[semantic-release](${HOME_URL})** bot :package::rocket:`
+  );
+});
+
+test('Comment with no release object', t => {
+  const issue = {number: 1};
+  const releaseInfos = [];
+  const nextRelease = {version: '1.0.0'};
+  const comment = getSuccessComment(issue, releaseInfos, nextRelease);
+
+  t.is(
+    comment,
+    `:tada: This issue has been resolved in version 1.0.0 :tada:
+
+Your **[semantic-release](${HOME_URL})** bot :package::rocket:`
+  );
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -105,7 +105,7 @@ test.serial('Throw SemanticReleaseError if invalid config', async t => {
   t.is(errors[1].name, 'SemanticReleaseError');
   t.is(errors[1].code, 'EINVALIDSUCCESSCOMMENT');
   t.is(errors[2].name, 'SemanticReleaseError');
-  t.is(errors[2].code, 'EINVALIDGITURL');
+  t.is(errors[2].code, 'EINVALIDGITHUBURL');
   t.is(errors[3].name, 'SemanticReleaseError');
   t.is(errors[3].code, 'ENOGHTOKEN');
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -147,8 +147,9 @@ test.serial('Publish a release with an array of assets', async t => {
     .post(`${uploadUri}?name=${escape('upload_other.txt')}&label=${escape('Other File')}`)
     .reply(200, {browser_download_url: otherAssetUrl});
 
-  await t.context.m.publish({assets}, {nextRelease, options, logger: t.context.logger});
+  const result = await t.context.m.publish({assets}, {nextRelease, options, logger: t.context.logger});
 
+  t.is(result.url, releaseUrl);
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
   t.deepEqual(t.context.log.args[1], ['Published GitHub release: %s', releaseUrl]);
   t.deepEqual(t.context.log.args[2], ['Published file %s', assetUrl]);

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -54,7 +54,7 @@ test.serial('Publish a release', async t => {
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
 
-  await publish(pluginConfig, options, nextRelease, t.context.logger);
+  await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
 
   t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
   t.true(github.isDone());
@@ -91,7 +91,7 @@ test.serial('Publish a release with one asset', async t => {
     .post(`${uploadUri}?name=${escape('.dotfile')}&label=${escape('A dotfile with no ext')}`)
     .reply(200, {browser_download_url: assetUrl});
 
-  await publish(pluginConfig, options, nextRelease, t.context.logger);
+  await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
 
   t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
   t.deepEqual(t.context.log.args[1], ['Published file %s', assetUrl]);
@@ -139,7 +139,7 @@ test.serial('Publish a release with one asset and custom github url', async t =>
     .post(`${uploadUri}?name=${escape('upload.txt')}&label=${escape('A text file')}`)
     .reply(200, {browser_download_url: assetUrl});
 
-  await publish(pluginConfig, options, nextRelease, t.context.logger);
+  await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
 
   t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
   t.deepEqual(t.context.log.args[1], ['Published file %s', assetUrl]);
@@ -169,7 +169,7 @@ test.serial('Publish a release with an array of missing assets', async t => {
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
 
-  await publish(pluginConfig, options, nextRelease, t.context.logger);
+  await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
 
   t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
   t.deepEqual(t.context.error.args[0], [

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -54,8 +54,9 @@ test.serial('Publish a release', async t => {
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
 
-  await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
+  const result = await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
 
+  t.is(result.url, releaseUrl);
   t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
   t.true(github.isDone());
 });
@@ -91,8 +92,9 @@ test.serial('Publish a release with one asset', async t => {
     .post(`${uploadUri}?name=${escape('.dotfile')}&label=${escape('A dotfile with no ext')}`)
     .reply(200, {browser_download_url: assetUrl});
 
-  await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
+  const result = await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
 
+  t.is(result.url, releaseUrl);
   t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
   t.deepEqual(t.context.log.args[1], ['Published file %s', assetUrl]);
   t.true(github.isDone());
@@ -139,8 +141,9 @@ test.serial('Publish a release with one asset and custom github url', async t =>
     .post(`${uploadUri}?name=${escape('upload.txt')}&label=${escape('A text file')}`)
     .reply(200, {browser_download_url: assetUrl});
 
-  await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
+  const result = await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
 
+  t.is(result.url, releaseUrl);
   t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
   t.deepEqual(t.context.log.args[1], ['Published file %s', assetUrl]);
   t.true(github.isDone());
@@ -169,8 +172,9 @@ test.serial('Publish a release with an array of missing assets', async t => {
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
 
-  await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
+  const result = await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
 
+  t.is(result.url, releaseUrl);
   t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
   t.deepEqual(t.context.error.args[0], [
     'The asset %s cannot be read, and will be ignored.',

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -1,0 +1,155 @@
+import {escape} from 'querystring';
+import test from 'ava';
+import nock from 'nock';
+import {stub} from 'sinon';
+import success from '../lib/success';
+import {authenticate} from './helpers/mock-github';
+
+/* eslint camelcase: ["error", {properties: "never"}] */
+
+// Save the current process.env
+const envBackup = Object.assign({}, process.env);
+
+test.beforeEach(t => {
+  // Delete env variables in case they are on the machine running the tests
+  delete process.env.GH_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_URL;
+  delete process.env.GITHUB_URL;
+  delete process.env.GH_PREFIX;
+  delete process.env.GITHUB_PREFIX;
+  // Mock logger
+  t.context.log = stub();
+  t.context.error = stub();
+  t.context.logger = {log: t.context.log, error: t.context.error};
+});
+
+test.afterEach.always(() => {
+  // Restore process.env
+  process.env = envBackup;
+  // Clear nock
+  nock.cleanAll();
+});
+
+test.serial('Add comment to PRs associated with release commits and issues closed by PR/commits comments', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
+  const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}, body: 'Fixes #3'}];
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const commits = [
+    {hash: '123', message: 'Commit 1 message\n\n Fix #1'},
+    {hash: '456', message: 'Commit 2 message'},
+    {hash: '789', message: 'Commit 3 message Closes #4'},
+  ];
+  const nextRelease = {version: '1.0.0'};
+  const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:pr'
+      )}`
+    )
+    .reply(200, {items: prs})
+    .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
+    .reply(200, {html_url: 'https://github.com/successcomment-1'})
+    .post(`/repos/${owner}/${repo}/issues/2/comments`, {body: /This PR is included/})
+    .reply(200, {html_url: 'https://github.com/successcomment-2'})
+    .post(`/repos/${owner}/${repo}/issues/3/comments`, {body: /This issue has been resolved/})
+    .reply(200, {html_url: 'https://github.com/successcomment-3'})
+    .post(`/repos/${owner}/${repo}/issues/4/comments`, {body: /This issue has been resolved/})
+    .reply(200, {html_url: 'https://github.com/successcomment-4'});
+
+  await success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args[0], ['Added comment to issue #%d: %s', 1, 'https://github.com/successcomment-1']);
+  t.deepEqual(t.context.log.args[1], ['Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2']);
+  t.deepEqual(t.context.log.args[2], ['Added comment to issue #%d: %s', 3, 'https://github.com/successcomment-3']);
+  t.deepEqual(t.context.log.args[3], ['Added comment to issue #%d: %s', 4, 'https://github.com/successcomment-4']);
+  t.true(github.isDone());
+});
+
+test.serial('Do not add comment if no PR is associated with release commits', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const nextRelease = {version: '1.0.0'};
+  const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:pr'
+      )}`
+    )
+    .reply(200, {items: []});
+
+  await success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger});
+
+  t.true(github.isDone());
+});
+
+test.serial('Ignore errors when adding comments', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
+  const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}}];
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const nextRelease = {version: '1.0.0'};
+  const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:pr'
+      )}`
+    )
+    .reply(200, {items: prs})
+    .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
+    .reply(404, {})
+    .post(`/repos/${owner}/${repo}/issues/2/comments`, {body: /This PR is included/})
+    .reply(200, {html_url: 'https://github.com/successcomment-2'});
+
+  const [error] = await t.throws(
+    success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger})
+  );
+
+  t.is(error.code, 404);
+  t.deepEqual(t.context.error.args[0], ['Failed to add a comment to the issue #%d.', 1]);
+  t.deepEqual(t.context.log.args[0], ['Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2']);
+  t.true(github.isDone());
+});
+
+test.serial('Add custom comment', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {
+    successComment: `last release: \${lastRelease.version} nextRelease: \${nextRelease.version} branch: \${branch} commits: \${commits.length} releases: \${releases.length} PR attribute: \${issue.prop}`,
+  };
+  const prs = [{number: 1, prop: 'PR prop', pull_request: {}}];
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const lastRelease = {version: '1.0.0'};
+  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const nextRelease = {version: '2.0.0'};
+  const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:pr'
+      )}`
+    )
+    .reply(200, {items: prs})
+    .post(`/repos/${owner}/${repo}/issues/1/comments`, {
+      body: /last release: 1\.0\.0 nextRelease: 2\.0\.0 branch: master commits: 1 releases: 1 PR attribute: PR prop/,
+    })
+    .reply(200, {html_url: 'https://github.com/successcomment-1'});
+
+  await success(pluginConfig, {options, lastRelease, commits, nextRelease, releases, logger: t.context.logger});
+
+  t.true(github.isDone());
+});

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -2,6 +2,7 @@ import {escape} from 'querystring';
 import test from 'ava';
 import nock from 'nock';
 import {stub} from 'sinon';
+import ISSUE_ID from '../lib/definitions/sr-issue-id';
 import success from '../lib/success';
 import {authenticate} from './helpers/mock-github';
 
@@ -35,7 +36,8 @@ test.serial('Add comment to PRs associated with release commits and issues close
   const owner = 'test_user';
   const repo = 'test_repo';
   process.env.GITHUB_TOKEN = 'github_token';
-  const pluginConfig = {};
+  const failTitle = 'The automated release is failing :rotating_light:';
+  const pluginConfig = {failTitle};
   const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}, body: 'Fixes #3'}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const commits = [
@@ -59,7 +61,13 @@ test.serial('Add comment to PRs associated with release commits and issues close
     .post(`/repos/${owner}/${repo}/issues/3/comments`, {body: /This issue has been resolved/})
     .reply(200, {html_url: 'https://github.com/successcomment-3'})
     .post(`/repos/${owner}/${repo}/issues/4/comments`, {body: /This issue has been resolved/})
-    .reply(200, {html_url: 'https://github.com/successcomment-4'});
+    .reply(200, {html_url: 'https://github.com/successcomment-4'})
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
+    )
+    .reply(200, {items: []});
 
   await success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger});
 
@@ -74,7 +82,8 @@ test.serial('Do not add comment if no PR is associated with release commits', as
   const owner = 'test_user';
   const repo = 'test_repo';
   process.env.GITHUB_TOKEN = 'github_token';
-  const pluginConfig = {};
+  const failTitle = 'The automated release is failing :rotating_light:';
+  const pluginConfig = {failTitle};
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const commits = [{hash: '123', message: 'Commit 1 message'}];
   const nextRelease = {version: '1.0.0'};
@@ -84,6 +93,12 @@ test.serial('Do not add comment if no PR is associated with release commits', as
       `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
         'type:pr'
       )}`
+    )
+    .reply(200, {items: []})
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
     )
     .reply(200, {items: []});
 
@@ -92,44 +107,14 @@ test.serial('Do not add comment if no PR is associated with release commits', as
   t.true(github.isDone());
 });
 
-test.serial('Ignore errors when adding comments', async t => {
-  const owner = 'test_user';
-  const repo = 'test_repo';
-  process.env.GITHUB_TOKEN = 'github_token';
-  const pluginConfig = {};
-  const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}}];
-  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
-  const commits = [{hash: '123', message: 'Commit 1 message'}];
-  const nextRelease = {version: '1.0.0'};
-  const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
-  const github = authenticate()
-    .get(
-      `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
-        'type:pr'
-      )}`
-    )
-    .reply(200, {items: prs})
-    .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
-    .reply(404, {})
-    .post(`/repos/${owner}/${repo}/issues/2/comments`, {body: /This PR is included/})
-    .reply(200, {html_url: 'https://github.com/successcomment-2'});
-
-  const [error] = await t.throws(
-    success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger})
-  );
-
-  t.is(error.code, 404);
-  t.deepEqual(t.context.error.args[0], ['Failed to add a comment to the issue #%d.', 1]);
-  t.deepEqual(t.context.log.args[0], ['Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2']);
-  t.true(github.isDone());
-});
-
 test.serial('Add custom comment', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
   process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'The automated release is failing :rotating_light:';
   const pluginConfig = {
     successComment: `last release: \${lastRelease.version} nextRelease: \${nextRelease.version} branch: \${branch} commits: \${commits.length} releases: \${releases.length} PR attribute: \${issue.prop}`,
+    failTitle,
   };
   const prs = [{number: 1, prop: 'PR prop', pull_request: {}}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
@@ -147,9 +132,106 @@ test.serial('Add custom comment', async t => {
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {
       body: /last release: 1\.0\.0 nextRelease: 2\.0\.0 branch: master commits: 1 releases: 1 PR attribute: PR prop/,
     })
-    .reply(200, {html_url: 'https://github.com/successcomment-1'});
+    .reply(200, {html_url: 'https://github.com/successcomment-1'})
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
+    )
+    .reply(200, {items: []});
 
   await success(pluginConfig, {options, lastRelease, commits, nextRelease, releases, logger: t.context.logger});
 
+  t.true(github.isDone());
+});
+
+test.serial('Ignore errors when adding comments and closing issues', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'The automated release is failing :rotating_light:';
+  const pluginConfig = {failTitle};
+  const issues = [
+    {number: 1, body: 'Issue 1 body', title: failTitle},
+    {number: 2, body: `Issue 2 body\n\n${ISSUE_ID}`, title: failTitle},
+    {number: 3, body: `Issue 3 body\n\n${ISSUE_ID}`, title: failTitle},
+  ];
+  const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}}];
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const nextRelease = {version: '1.0.0'};
+  const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:pr'
+      )}`
+    )
+    .reply(200, {items: prs})
+    .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
+    .reply(404, {})
+    .post(`/repos/${owner}/${repo}/issues/2/comments`, {body: /This PR is included/})
+    .reply(200, {html_url: 'https://github.com/successcomment-2'})
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
+    )
+    .reply(200, {items: issues})
+    .patch(`/repos/${owner}/${repo}/issues/2`, {state: 'closed'})
+    .reply(500)
+    .patch(`/repos/${owner}/${repo}/issues/3`, {state: 'closed'})
+    .reply(200, {html_url: 'https://github.com/issues/3'});
+
+  const [error1, error2] = await t.throws(
+    success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger})
+  );
+
+  t.is(error1.code, 404);
+  t.is(error2.code, 500);
+  t.deepEqual(t.context.error.args[0], ['Failed to add a comment to the issue #%d.', 1]);
+  t.deepEqual(t.context.error.args[1], ['Failed to close the issue #%d.', 2]);
+  t.deepEqual(t.context.log.args[0], ['Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2']);
+  t.deepEqual(t.context.log.args[1], ['Closed issue #%d: %s.', 3, 'https://github.com/issues/3']);
+  t.true(github.isDone());
+});
+
+test.serial('Close open issues when a release is successful', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'The automated release is failing :rotating_light:';
+  const pluginConfig = {failTitle};
+  const issues = [
+    {number: 1, body: 'Issue 1 body', title: failTitle},
+    {number: 2, body: `Issue 2 body\n\n${ISSUE_ID}`, title: failTitle},
+    {number: 3, body: `Issue 3 body\n\n${ISSUE_ID}`, title: failTitle},
+  ];
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const nextRelease = {version: '1.0.0'};
+  const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:pr'
+      )}`
+    )
+    .reply(200, {items: []})
+    .get(
+      `/search/issues?q=${escape(`title:${failTitle}`)}+${escape(`repo:${owner}/${repo}`)}+${escape(
+        'type:issue'
+      )}+${escape('state:open')}`
+    )
+    .reply(200, {items: issues})
+    .patch(`/repos/${owner}/${repo}/issues/2`, {state: 'closed'})
+    .reply(200, {html_url: 'https://github.com/issues/2'})
+    .patch(`/repos/${owner}/${repo}/issues/3`, {state: 'closed'})
+    .reply(200, {html_url: 'https://github.com/issues/3'});
+
+  await success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args[0], ['Closed issue #%d: %s.', 2, 'https://github.com/issues/2']);
+  t.deepEqual(t.context.log.args[1], ['Closed issue #%d: %s.', 3, 'https://github.com/issues/3']);
   t.true(github.isDone());
 });

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -317,7 +317,7 @@ test.serial('Throw SemanticReleaseError for invalid repositoryUrl', async t => {
   const [error] = await t.throws(verify({}, {options: {repositoryUrl: 'invalid_url'}, logger: t.context.logger}));
 
   t.is(error.name, 'SemanticReleaseError');
-  t.is(error.code, 'EINVALIDGITURL');
+  t.is(error.code, 'EINVALIDGITHUBURL');
 });
 
 test.serial("Throw SemanticReleaseError if token doesn't have the push permission on the repository", async t => {

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -39,7 +39,10 @@ test.serial('Verify package, token and repository access', async t => {
     .reply(200, {permissions: {push: true}});
 
   await t.notThrows(
-    verify({assets}, {repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`}, t.context.logger)
+    verify(
+      {assets},
+      {options: {repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`}, logger: t.context.logger}
+    )
   );
   t.true(github.isDone());
 });
@@ -57,8 +60,7 @@ test.serial('Verify package, token and repository access and custom URL with pre
   await t.notThrows(
     verify(
       {githubUrl, githubApiPathPrefix},
-      {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`},
-      t.context.logger
+      {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger}
     )
   );
 
@@ -76,7 +78,10 @@ test.serial('Verify package, token and repository access and custom URL without 
     .reply(200, {permissions: {push: true}});
 
   await t.notThrows(
-    verify({githubUrl}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger)
+    verify(
+      {githubUrl},
+      {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger}
+    )
   );
 
   t.true(github.isDone());
@@ -93,7 +98,9 @@ test.serial('Verify package, token and repository with environment variables', a
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(verify({}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+  await t.notThrows(
+    verify({}, {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger})
+  );
 
   t.true(github.isDone());
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication (%s)', 'https://othertesturl.com:443/prefix']);
@@ -110,7 +117,9 @@ test.serial('Verify package, token and repository access with alternative enviro
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(verify({}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+  await t.notThrows(
+    verify({}, {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger})
+  );
   t.true(github.isDone());
 });
 
@@ -119,7 +128,10 @@ test.serial('Throw SemanticReleaseError if "assets" option is not a String or an
   const assets = 42;
 
   const error = await t.throws(
-    verify({assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
+    verify(
+      {assets},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -131,7 +143,10 @@ test.serial('Throw SemanticReleaseError if "assets" option is an Array with inva
   const assets = ['file.js', 42];
 
   const error = await t.throws(
-    verify({assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
+    verify(
+      {assets},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -147,7 +162,9 @@ test.serial('Verify "assets" is a String', async t => {
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+  await t.notThrows(
+    verify({assets}, {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger})
+  );
 
   t.true(github.isDone());
 });
@@ -161,7 +178,9 @@ test.serial('Verify "assets" is an Object with a path property', async t => {
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+  await t.notThrows(
+    verify({assets}, {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger})
+  );
 
   t.true(github.isDone());
 });
@@ -175,7 +194,9 @@ test.serial('Verify "assets" is an Array of Object with a path property', async 
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+  await t.notThrows(
+    verify({assets}, {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger})
+  );
 
   t.true(github.isDone());
 });
@@ -189,7 +210,9 @@ test.serial('Verify "assets" is an Array of glob Arrays', async t => {
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+  await t.notThrows(
+    verify({assets}, {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger})
+  );
 
   t.true(github.isDone());
 });
@@ -203,7 +226,9 @@ test.serial('Verify "assets" is an Array of Object with a glob Arrays in path pr
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(verify({assets}, {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, t.context.logger));
+  await t.notThrows(
+    verify({assets}, {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger})
+  );
 
   t.true(github.isDone());
 });
@@ -213,7 +238,10 @@ test.serial('Throw SemanticReleaseError if "assets" option is an Object missing 
   const assets = {name: 'file.js'};
 
   const error = await t.throws(
-    verify({assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
+    verify(
+      {assets},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -227,7 +255,10 @@ test.serial(
     const assets = [{path: 'lib/file.js'}, {name: 'file.js'}];
 
     const error = await t.throws(
-      verify({assets}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
+      verify(
+        {assets},
+        {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+      )
     );
 
     t.true(error instanceof SemanticReleaseError);
@@ -237,7 +268,7 @@ test.serial(
 
 test.serial('Throw SemanticReleaseError for missing github token', async t => {
   const error = await t.throws(
-    verify({}, {repositoryUrl: 'https://github.com/semantic-release/github.git'}, t.context.logger)
+    verify({}, {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger})
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -253,7 +284,7 @@ test.serial('Throw SemanticReleaseError for invalid token', async t => {
     .reply(401);
 
   const error = await t.throws(
-    verify({}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
+    verify({}, {options: {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, logger: t.context.logger})
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -264,7 +295,7 @@ test.serial('Throw SemanticReleaseError for invalid token', async t => {
 test.serial('Throw SemanticReleaseError for invalid repositoryUrl', async t => {
   process.env.GITHUB_TOKEN = 'github_token';
 
-  const error = await t.throws(verify({}, {repositoryUrl: 'invalid_url'}, t.context.logger));
+  const error = await t.throws(verify({}, {options: {repositoryUrl: 'invalid_url'}, logger: t.context.logger}));
 
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'EINVALIDGITURL');
@@ -279,7 +310,7 @@ test.serial("Throw SemanticReleaseError if token doesn't have the push permissio
     .reply(200, {permissions: {push: false}});
 
   const error = await t.throws(
-    verify({}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
+    verify({}, {options: {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, logger: t.context.logger})
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -296,7 +327,7 @@ test.serial("Throw SemanticReleaseError if the repository doesn't exist", async 
     .reply(404);
 
   const error = await t.throws(
-    verify({}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
+    verify({}, {options: {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, logger: t.context.logger})
   );
 
   t.true(error instanceof SemanticReleaseError);
@@ -313,7 +344,7 @@ test.serial('Throw error if github return any other errors', async t => {
     .reply(500);
 
   const error = await t.throws(
-    verify({}, {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, t.context.logger)
+    verify({}, {options: {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, logger: t.context.logger})
   );
 
   t.is(error.code, 500);

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -34,37 +34,46 @@ test.serial('Verify package, token and repository access', async t => {
   process.env.GH_TOKEN = 'github_token';
   const assets = [{path: 'lib/file.js'}, 'file.js'];
   const successComment = 'Test comment';
+  const failTitle = 'Test title';
+  const failComment = 'Test comment';
+  const labels = ['semantic-release'];
   const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}});
 
   await t.notThrows(
     verify(
-      {assets, successComment},
+      {assets, successComment, failTitle, failComment, labels},
       {options: {repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`}, logger: t.context.logger}
     )
   );
   t.true(github.isDone());
 });
 
-test.serial('Verify package, token and repository access with "asset" and "successComment" set to "false"', async t => {
-  const owner = 'test_user';
-  const repo = 'test_repo';
-  process.env.GH_TOKEN = 'github_token';
-  const assets = false;
-  const successComment = false;
-  const github = authenticate()
-    .get(`/repos/${owner}/${repo}`)
-    .reply(200, {permissions: {push: true}});
+test.serial(
+  'Verify package, token and repository access with "asset", "successComment", "failTitle", "failComment" and "label" set to "false"',
+  async t => {
+    const owner = 'test_user';
+    const repo = 'test_repo';
+    process.env.GH_TOKEN = 'github_token';
+    const assets = false;
+    const successComment = false;
+    const failTitle = false;
+    const failComment = false;
+    const labels = false;
+    const github = authenticate()
+      .get(`/repos/${owner}/${repo}`)
+      .reply(200, {permissions: {push: true}});
 
-  await t.notThrows(
-    verify(
-      {assets, successComment},
-      {options: {repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`}, logger: t.context.logger}
-    )
-  );
-  t.true(github.isDone());
-});
+    await t.notThrows(
+      verify(
+        {assets, successComment, failTitle, failComment, labels},
+        {options: {repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`}, logger: t.context.logger}
+      )
+    );
+    t.true(github.isDone());
+  }
+);
 
 test.serial('Verify package, token and repository access and custom URL with prefix', async t => {
   const owner = 'test_user';
@@ -140,36 +149,6 @@ test.serial('Verify package, token and repository access with alternative enviro
     verify({}, {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger})
   );
   t.true(github.isDone());
-});
-
-test.serial('Throw SemanticReleaseError if "assets" option is not a String or an Array of Objects', async t => {
-  process.env.GITHUB_TOKEN = 'github_token';
-  const assets = 42;
-
-  const [error] = await t.throws(
-    verify(
-      {assets},
-      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
-    )
-  );
-
-  t.is(error.name, 'SemanticReleaseError');
-  t.is(error.code, 'EINVALIDASSETS');
-});
-
-test.serial('Throw SemanticReleaseError if "assets" option is an Array with invalid elements', async t => {
-  process.env.GITHUB_TOKEN = 'github_token';
-  const assets = ['file.js', 42];
-
-  const [error] = await t.throws(
-    verify(
-      {assets},
-      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
-    )
-  );
-
-  t.is(error.name, 'SemanticReleaseError');
-  t.is(error.code, 'EINVALIDASSETS');
 });
 
 test.serial('Verify "assets" is a String', async t => {
@@ -252,38 +231,40 @@ test.serial('Verify "assets" is an Array of Object with a glob Arrays in path pr
   t.true(github.isDone());
 });
 
-test.serial('Throw SemanticReleaseError if "assets" option is an Object missing the "path" property', async t => {
+test.serial('Verify "labels" is a String', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
   process.env.GITHUB_TOKEN = 'github_token';
-  const assets = {name: 'file.js'};
+  const labels = 'semantic-release';
+  const github = authenticate()
+    .get(`/repos/${owner}/${repo}`)
+    .reply(200, {permissions: {push: true}});
 
-  const [error] = await t.throws(
+  await t.notThrows(
+    verify({labels}, {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger})
+  );
+
+  t.true(github.isDone());
+});
+
+test.serial('Verify "assignees" is a String', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const assignees = 'user';
+  const github = authenticate()
+    .get(`/repos/${owner}/${repo}`)
+    .reply(200, {permissions: {push: true}});
+
+  await t.notThrows(
     verify(
-      {assets},
-      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+      {assignees},
+      {options: {repositoryUrl: `git@othertesturl.com:${owner}/${repo}.git`}, logger: t.context.logger}
     )
   );
 
-  t.is(error.name, 'SemanticReleaseError');
-  t.is(error.code, 'EINVALIDASSETS');
+  t.true(github.isDone());
 });
-
-test.serial(
-  'Throw SemanticReleaseError if "assets" option is an Array with objects missing the "path" property',
-  async t => {
-    process.env.GITHUB_TOKEN = 'github_token';
-    const assets = [{path: 'lib/file.js'}, {name: 'file.js'}];
-
-    const [error] = await t.throws(
-      verify(
-        {assets},
-        {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
-      )
-    );
-
-    t.is(error.name, 'SemanticReleaseError');
-    t.is(error.code, 'EINVALIDASSETS');
-  }
-);
 
 test.serial('Throw SemanticReleaseError for missing github token', async t => {
   const [error] = await t.throws(
@@ -370,6 +351,69 @@ test.serial('Throw error if github return any other errors', async t => {
   t.true(github.isDone());
 });
 
+test.serial('Throw SemanticReleaseError if "assets" option is not a String or an Array of Objects', async t => {
+  process.env.GITHUB_TOKEN = 'github_token';
+  const assets = 42;
+
+  const [error] = await t.throws(
+    verify(
+      {assets},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDASSETS');
+});
+
+test.serial('Throw SemanticReleaseError if "assets" option is an Array with invalid elements', async t => {
+  process.env.GITHUB_TOKEN = 'github_token';
+  const assets = ['file.js', 42];
+
+  const [error] = await t.throws(
+    verify(
+      {assets},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDASSETS');
+});
+
+test.serial('Throw SemanticReleaseError if "assets" option is an Object missing the "path" property', async t => {
+  process.env.GITHUB_TOKEN = 'github_token';
+  const assets = {name: 'file.js'};
+
+  const [error] = await t.throws(
+    verify(
+      {assets},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDASSETS');
+});
+
+test.serial(
+  'Throw SemanticReleaseError if "assets" option is an Array with objects missing the "path" property',
+  async t => {
+    process.env.GITHUB_TOKEN = 'github_token';
+    const assets = [{path: 'lib/file.js'}, {name: 'file.js'}];
+
+    const [error] = await t.throws(
+      verify(
+        {assets},
+        {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+      )
+    );
+
+    t.is(error.name, 'SemanticReleaseError');
+    t.is(error.code, 'EINVALIDASSETS');
+  }
+);
+
 test('Throw SemanticReleaseError if "successComment" option is not a String', async t => {
   const successComment = 42;
   const [error] = await t.throws(
@@ -407,4 +451,168 @@ test('Throw SemanticReleaseError if "successComment" option is a whitespace Stri
 
   t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDSUCCESSCOMMENT');
+});
+
+test('Throw SemanticReleaseError if "failTitle" option is not a String', async t => {
+  const failTitle = 42;
+  const [error] = await t.throws(
+    verify(
+      {failTitle},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDFAILTITLE');
+});
+
+test('Throw SemanticReleaseError if "failTitle" option is an empty String', async t => {
+  const failTitle = '';
+  const [error] = await t.throws(
+    verify(
+      {failTitle},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDFAILTITLE');
+});
+
+test('Throw SemanticReleaseError if "failTitle" option is a whitespace String', async t => {
+  const failTitle = '  \n \r ';
+  const [error] = await t.throws(
+    verify(
+      {failTitle},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDFAILTITLE');
+});
+
+test('Throw SemanticReleaseError if "failComment" option is not a String', async t => {
+  const failComment = 42;
+  const [error] = await t.throws(
+    verify(
+      {failComment},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDFAILCOMMENT');
+});
+
+test('Throw SemanticReleaseError if "failComment" option is an empty String', async t => {
+  const failComment = '';
+  const [error] = await t.throws(
+    verify(
+      {failComment},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDFAILCOMMENT');
+});
+
+test('Throw SemanticReleaseError if "failComment" option is a whitespace String', async t => {
+  const failComment = '  \n \r ';
+  const [error] = await t.throws(
+    verify(
+      {failComment},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDFAILCOMMENT');
+});
+
+test.serial('Throw SemanticReleaseError if "labels" option is not a String or an Array of String', async t => {
+  process.env.GITHUB_TOKEN = 'github_token';
+  const labels = 42;
+
+  const [error] = await t.throws(
+    verify(
+      {labels},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDLABELS');
+});
+
+test.serial('Throw SemanticReleaseError if "labels" option is an Array with invalid elements', async t => {
+  process.env.GITHUB_TOKEN = 'github_token';
+  const labels = ['label1', 42];
+
+  const [error] = await t.throws(
+    verify(
+      {labels},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDLABELS');
+});
+
+test('Throw SemanticReleaseError if "labels" option is a whitespace String', async t => {
+  const labels = '  \n \r ';
+  const [error] = await t.throws(
+    verify(
+      {labels},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDLABELS');
+});
+
+test.serial('Throw SemanticReleaseError if "assignees" option is not a String or an Array of String', async t => {
+  process.env.GITHUB_TOKEN = 'github_token';
+  const assignees = 42;
+
+  const [error] = await t.throws(
+    verify(
+      {assignees},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDASSIGNEES');
+});
+
+test.serial('Throw SemanticReleaseError if "assignees" option is an Array with invalid elements', async t => {
+  process.env.GITHUB_TOKEN = 'github_token';
+  const assignees = ['user', 42];
+
+  const [error] = await t.throws(
+    verify(
+      {assignees},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDASSIGNEES');
+});
+
+test('Throw SemanticReleaseError if "assignees" option is a whitespace String', async t => {
+  const assignees = '  \n \r ';
+  const [error] = await t.throws(
+    verify(
+      {assignees},
+      {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
+    )
+  );
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDASSIGNEES');
 });

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -1,7 +1,6 @@
 import test from 'ava';
 import nock from 'nock';
 import {stub} from 'sinon';
-import SemanticReleaseError from '@semantic-release/error';
 import verify from '../lib/verify';
 import {authenticate} from './helpers/mock-github';
 
@@ -147,14 +146,14 @@ test.serial('Throw SemanticReleaseError if "assets" option is not a String or an
   process.env.GITHUB_TOKEN = 'github_token';
   const assets = 42;
 
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify(
       {assets},
       {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
     )
   );
 
-  t.true(error instanceof SemanticReleaseError);
+  t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDASSETS');
 });
 
@@ -162,14 +161,14 @@ test.serial('Throw SemanticReleaseError if "assets" option is an Array with inva
   process.env.GITHUB_TOKEN = 'github_token';
   const assets = ['file.js', 42];
 
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify(
       {assets},
       {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
     )
   );
 
-  t.true(error instanceof SemanticReleaseError);
+  t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDASSETS');
 });
 
@@ -257,14 +256,14 @@ test.serial('Throw SemanticReleaseError if "assets" option is an Object missing 
   process.env.GITHUB_TOKEN = 'github_token';
   const assets = {name: 'file.js'};
 
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify(
       {assets},
       {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
     )
   );
 
-  t.true(error instanceof SemanticReleaseError);
+  t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDASSETS');
 });
 
@@ -274,24 +273,24 @@ test.serial(
     process.env.GITHUB_TOKEN = 'github_token';
     const assets = [{path: 'lib/file.js'}, {name: 'file.js'}];
 
-    const error = await t.throws(
+    const [error] = await t.throws(
       verify(
         {assets},
         {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
       )
     );
 
-    t.true(error instanceof SemanticReleaseError);
+    t.is(error.name, 'SemanticReleaseError');
     t.is(error.code, 'EINVALIDASSETS');
   }
 );
 
 test.serial('Throw SemanticReleaseError for missing github token', async t => {
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify({}, {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger})
   );
 
-  t.true(error instanceof SemanticReleaseError);
+  t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'ENOGHTOKEN');
 });
 
@@ -303,11 +302,11 @@ test.serial('Throw SemanticReleaseError for invalid token', async t => {
     .get(`/repos/${owner}/${repo}`)
     .reply(401);
 
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify({}, {options: {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, logger: t.context.logger})
   );
 
-  t.true(error instanceof SemanticReleaseError);
+  t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDGHTOKEN');
   t.true(github.isDone());
 });
@@ -315,9 +314,9 @@ test.serial('Throw SemanticReleaseError for invalid token', async t => {
 test.serial('Throw SemanticReleaseError for invalid repositoryUrl', async t => {
   process.env.GITHUB_TOKEN = 'github_token';
 
-  const error = await t.throws(verify({}, {options: {repositoryUrl: 'invalid_url'}, logger: t.context.logger}));
+  const [error] = await t.throws(verify({}, {options: {repositoryUrl: 'invalid_url'}, logger: t.context.logger}));
 
-  t.true(error instanceof SemanticReleaseError);
+  t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDGITURL');
 });
 
@@ -329,11 +328,11 @@ test.serial("Throw SemanticReleaseError if token doesn't have the push permissio
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: false}});
 
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify({}, {options: {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, logger: t.context.logger})
   );
 
-  t.true(error instanceof SemanticReleaseError);
+  t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EGHNOPERMISSION');
   t.true(github.isDone());
 });
@@ -346,11 +345,11 @@ test.serial("Throw SemanticReleaseError if the repository doesn't exist", async 
     .get(`/repos/${owner}/${repo}`)
     .reply(404);
 
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify({}, {options: {repositoryUrl: `https://github.com:${owner}/${repo}.git`}, logger: t.context.logger})
   );
 
-  t.true(error instanceof SemanticReleaseError);
+  t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EMISSINGREPO');
   t.true(github.isDone());
 });
@@ -372,9 +371,8 @@ test.serial('Throw error if github return any other errors', async t => {
 });
 
 test('Throw SemanticReleaseError if "successComment" option is not a String', async t => {
-  process.env.GITHUB_TOKEN = 'github_token';
   const successComment = 42;
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify(
       {successComment},
       {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
@@ -386,9 +384,8 @@ test('Throw SemanticReleaseError if "successComment" option is not a String', as
 });
 
 test('Throw SemanticReleaseError if "successComment" option is an empty String', async t => {
-  process.env.GITHUB_TOKEN = 'github_token';
   const successComment = '';
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify(
       {successComment},
       {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}
@@ -400,9 +397,8 @@ test('Throw SemanticReleaseError if "successComment" option is an empty String',
 });
 
 test('Throw SemanticReleaseError if "successComment" option is a whitespace String', async t => {
-  process.env.GITHUB_TOKEN = 'github_token';
   const successComment = '  \n \r ';
-  const error = await t.throws(
+  const [error] = await t.throws(
     verify(
       {successComment},
       {options: {repositoryUrl: 'https://github.com/semantic-release/github.git'}, logger: t.context.logger}


### PR DESCRIPTION
- [x] `success`: add comment to issues and pull requests included in the release
- [x] Return release informations from `publish` hook
- [x] Add error details to all `SemanticReleaseError`s
- [x] Return all errors so semantic-release can report multiple errors at once
- [x] `fail`: open an issue when a release fails