### PR TITLE
fix: make search queries of 256 characters maximum

### DIFF
--- a/lib/get-search-queries.js
+++ b/lib/get-search-queries.js
@@ -1,0 +1,12 @@
+module.exports = (base, commits, separator = '+') => {
+  return commits.reduce((searches, commit) => {
+    const lastSearch = searches[searches.length - 1];
+
+    if (lastSearch && lastSearch.length + commit.length <= 256 - separator.length) {
+      searches[searches.length - 1] = `${lastSearch}${separator}${commit}`;
+    } else {
+      searches.push(`${base}${separator}${commit}`);
+    }
+    return searches;
+  }, []);
+};

--- a/lib/success.js
+++ b/lib/success.js
@@ -6,6 +6,7 @@ const issueParser = require('issue-parser')('github');
 const debug = require('debug')('semantic-release:github');
 const resolveConfig = require('./resolve-config');
 const getClient = require('./get-client');
+const getSearchQueries = require('./get-search-queries');
 const getSuccessComment = require('./get-success-comment');
 const findSRIssues = require('./find-sr-issues');
 
@@ -18,10 +19,14 @@ module.exports = async (
   const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
   const releaseInfos = releases.filter(release => Boolean(release.name));
 
-  // Search for PRs associated with any commit in the release
-  const {data: {items: prs}} = await github.search.issues({
-    q: `${commits.map(commit => commit.hash).join('+')}+repo:${owner}/${repo}+type:pr`,
-  });
+  const prs = await pReduce(
+    getSearchQueries(`repo:${owner}/${repo}+type:pr`, commits.map(commit => commit.hash)),
+    async (prs, q) => {
+      const {data: {items}} = await github.search.issues({q});
+      return [...prs, ...items];
+    },
+    []
+  );
 
   debug('found pull requests: %O', prs.map(pr => pr.number));
 

--- a/test/get-search-queries.test.js
+++ b/test/get-search-queries.test.js
@@ -1,0 +1,34 @@
+import test from 'ava';
+import {repeat} from 'lodash';
+import getSearchQueries from '../lib/get-search-queries';
+
+test('Generate queries of 256 characters maximum', t => {
+  const commits = [
+    repeat('a', 40),
+    repeat('b', 40),
+    repeat('c', 40),
+    repeat('d', 40),
+    repeat('e', 40),
+    repeat('f', 40),
+  ];
+
+  t.deepEqual(getSearchQueries(repeat('0', 51), commits), [
+    `${repeat('0', 51)}+${commits[0]}+${commits[1]}+${commits[2]}+${commits[3]}+${commits[4]}`,
+    `${repeat('0', 51)}+${commits[5]}`,
+  ]);
+
+  t.deepEqual(getSearchQueries(repeat('0', 52), commits), [
+    `${repeat('0', 52)}+${commits[0]}+${commits[1]}+${commits[2]}+${commits[3]}`,
+    `${repeat('0', 52)}+${commits[4]}+${commits[5]}`,
+  ]);
+});
+
+test('Generate one query if it is less tahn 256 characters', t => {
+  const commits = [repeat('a', 40), repeat('b', 40)];
+
+  t.deepEqual(getSearchQueries(repeat('0', 20), commits), [`${repeat('0', 20)}+${commits[0]}+${commits[1]}`]);
+});
+
+test('Return emty Array if there is no commits', t => {
+  t.deepEqual(getSearchQueries('base', []), []);
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -192,9 +192,9 @@ test.serial('Comment on PR included in the releases', async t => {
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}})
     .get(
-      `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
-        'type:pr'
-      )}`
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+        .map(commit => commit.hash)
+        .join('+')}`
     )
     .reply(200, {items: prs})
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
@@ -281,9 +281,9 @@ test.serial('Verify, release and notify success', async t => {
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl})
     .get(
-      `/search/issues?q=${commits.map(commit => commit.hash).join('+')}+${escape(`repo:${owner}/${repo}`)}+${escape(
-        'type:pr'
-      )}`
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+        .map(commit => commit.hash)
+        .join('+')}`
     )
     .reply(200, {items: prs})
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})


### PR DESCRIPTION
Fix #34

It turns out the GitHub API access a query string of maximum 256 characters for the [search issue](https://developer.github.com/v3/search/#search-issues) endpoint.

This PR craft queries to fit that limit. The minimum number of queries possible will be executed.