### PR TITLE
feat: retry GitHub API calls with exponential backoff

### DIFF
--- a/lib/get-client.js
+++ b/lib/get-client.js
@@ -1,7 +1,29 @@
 const url = require('url');
+const {get, set} = require('lodash');
 const GitHubApi = require('@octokit/rest');
+const pRetry = require('p-retry');
 
-module.exports = (githubToken, githubUrl, githubApiPathPrefix) => {
+/**
+ * Exponential backoff configuration for retries.
+ */
+const DEFAULT_RETRY = {retries: 3, factor: 2, minTimeout: 1000};
+/**
+ * Octokit functions to retry.
+ */
+const RETRY_FUNCTIONS = [
+  'repos.createRelease',
+  'repos.uploadAsset',
+  'search.issues',
+  'issues.create',
+  'issues.edit',
+  'issues.createComment',
+];
+/**
+ * Http error codes for which to not retry.
+ */
+const SKIP_RETRY_CODES = [400, 401, 403];
+
+module.exports = (githubToken, githubUrl, githubApiPathPrefix, retryConf = DEFAULT_RETRY) => {
   const {port, protocol, hostname} = githubUrl ? url.parse(githubUrl) : {};
   const github = new GitHubApi({
     port,
@@ -10,5 +32,26 @@ module.exports = (githubToken, githubUrl, githubApiPathPrefix) => {
     pathPrefix: githubApiPathPrefix,
   });
   github.authenticate({type: 'token', token: githubToken});
+  retryable(github, RETRY_FUNCTIONS, retryConf);
+
   return github;
 };
+
+function retryable(obj, props, retryConf) {
+  for (const prop of props) {
+    const func = get(obj, prop);
+    set(obj, prop, (...args) =>
+      pRetry(async () => {
+        try {
+          return await func(...args);
+        } catch (err) {
+          if (SKIP_RETRY_CODES.includes(err.code)) {
+            // If the API return a 400, 401 or 403 error, do not retry
+            throw new pRetry.AbortError(err);
+          }
+          throw err;
+        }
+      }, retryConf)
+    );
+  }
+}

--- a/lib/get-client.js
+++ b/lib/get-client.js
@@ -1,49 +1,49 @@
 const url = require('url');
-const {get, set} = require('lodash');
-const GitHubApi = require('@octokit/rest');
+const Octokit = require('@octokit/rest');
+const octokitRequest = require('@octokit/rest/lib/request');
 const pRetry = require('p-retry');
+const delay = require('delay');
 
-/**
- * Exponential backoff configuration for retries.
- */
-const DEFAULT_RETRY = {retries: 3, factor: 2, minTimeout: 1000};
-/**
- * Octokit functions to retry.
- */
-const RETRY_FUNCTIONS = [
-  'repos.createRelease',
-  'repos.uploadAsset',
-  'search.issues',
-  'issues.create',
-  'issues.edit',
-  'issues.createComment',
-];
 /**
  * Http error codes for which to not retry.
  */
 const SKIP_RETRY_CODES = [400, 401, 403];
 
-module.exports = (githubToken, githubUrl, githubApiPathPrefix, retryConf = DEFAULT_RETRY) => {
+module.exports = (githubToken, githubUrl, githubApiPathPrefix, retry = {retries: 3, factor: 2, minTimeout: 1000}) => {
   const {port, protocol, hostname} = githubUrl ? url.parse(githubUrl) : {};
-  const github = new GitHubApi({
+  const github = new Octokit({
     port,
     protocol: (protocol || '').split(':')[0] || null,
     host: hostname,
     pathPrefix: githubApiPathPrefix,
   });
+
+  const initialDelay = retry.minTimeout;
+  const retryConf = {
+    factor: retry.factor,
+    minTimeout: retry.minTimeout * retry.factor,
+    retries: retry.retries - 1,
+    maxTimeout: retry.maxTimeout,
+  };
+
+  github.plugin(retryPlugin(retryConf, initialDelay));
   github.authenticate({type: 'token', token: githubToken});
-  retryable(github, RETRY_FUNCTIONS, retryConf);
 
   return github;
 };
 
-function retryable(obj, props, retryConf) {
-  for (const prop of props) {
-    const func = get(obj, prop);
-    set(obj, prop, (...args) =>
-      pRetry(async () => {
+function retryPlugin(retry, initialDelay) {
+  return octokit =>
+    octokit.hook.error('request', async (error, options) => {
+      if (SKIP_RETRY_CODES.includes(error.code)) {
+        throw error;
+      }
+
+      await delay(initialDelay);
+
+      return pRetry(async () => {
         try {
-          return await func(...args);
+          return await octokitRequest(options);
         } catch (err) {
           if (SKIP_RETRY_CODES.includes(err.code)) {
             // If the API return a 400, 401 or 403 error, do not retry
@@ -51,7 +51,6 @@ function retryable(obj, props, retryConf) {
           }
           throw err;
         }
-      }, retryConf)
-    );
-  }
+      }, retry);
+    });
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@semantic-release/error": "^2.2.0",
     "aggregate-error": "^1.0.0",
     "debug": "^3.1.0",
+    "delay": "^2.0.0",
     "fs-extra": "^5.0.0",
     "globby": "^8.0.0",
     "issue-parser": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lodash": "^4.17.4",
     "mime": "^2.0.3",
     "p-reduce": "^1.0.0",
+    "p-retry": "^1.0.0",
     "parse-github-url": "^1.0.1",
     "url-join": "^4.0.0"
   },
@@ -40,6 +41,7 @@
     "nock": "^9.1.0",
     "nyc": "^11.2.1",
     "prettier": "~1.10.0",
+    "proxyquire": "^1.8.0",
     "semantic-release": "^12.2.2",
     "sinon": "^4.0.0",
     "tempy": "^0.2.1",

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -3,11 +3,17 @@ import test from 'ava';
 import {stat} from 'fs-extra';
 import nock from 'nock';
 import {stub} from 'sinon';
+import proxyquire from 'proxyquire';
 import tempy from 'tempy';
-import publish from '../lib/publish';
+import getClient from '../lib/get-client';
 import {authenticate, upload} from './helpers/mock-github';
 
 /* eslint camelcase: ["error", {properties: "never"}] */
+
+const publish = proxyquire('../lib/publish', {
+  './get-client': (githubToken, githubUrl, githubApiPathPrefix) =>
+    getClient(githubToken, githubUrl, githubApiPathPrefix, {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}),
+});
 
 // Save the current process.env
 const envBackup = Object.assign({}, process.env);
@@ -46,6 +52,42 @@ test.serial('Publish a release', async t => {
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
 
   const github = authenticate()
+    .post(`/repos/${owner}/${repo}/releases`, {
+      tag_name: nextRelease.gitTag,
+      target_commitish: options.branch,
+      name: nextRelease.gitTag,
+      body: nextRelease.notes,
+    })
+    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
+
+  const result = await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
+
+  t.is(result.url, releaseUrl);
+  t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
+  t.true(github.isDone());
+});
+
+test.serial('Publish a release, retrying 4 times', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
+  const nextRelease = {version: '1.0.0', gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
+  const releaseId = 1;
+  const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
+  const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
+
+  const github = authenticate()
+    .post(`/repos/${owner}/${repo}/releases`, {
+      tag_name: nextRelease.gitTag,
+      target_commitish: options.branch,
+      name: nextRelease.gitTag,
+      body: nextRelease.notes,
+    })
+    .times(3)
+    .reply(404)
     .post(`/repos/${owner}/${repo}/releases`, {
       tag_name: nextRelease.gitTag,
       target_commitish: options.branch,
@@ -181,5 +223,35 @@ test.serial('Publish a release with an array of missing assets', async t => {
     'test/fixtures/missing.txt',
   ]);
   t.deepEqual(t.context.error.args[1], ['The asset %s is not a file, and will be ignored.', emptyDirectory]);
+  t.true(github.isDone());
+});
+
+test.serial('Throw error without retries for 400 error', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
+  const nextRelease = {version: '1.0.0', gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+
+  const github = authenticate()
+    .post(`/repos/${owner}/${repo}/releases`, {
+      tag_name: nextRelease.gitTag,
+      target_commitish: options.branch,
+      name: nextRelease.gitTag,
+      body: nextRelease.notes,
+    })
+    .reply(404)
+    .post(`/repos/${owner}/${repo}/releases`, {
+      tag_name: nextRelease.gitTag,
+      target_commitish: options.branch,
+      name: nextRelease.gitTag,
+      body: nextRelease.notes,
+    })
+    .reply(400);
+
+  const error = await t.throws(publish(pluginConfig, {options, nextRelease, logger: t.context.logger}));
+
+  t.is(error.code, 400);
   t.true(github.isDone());
 });

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -1,11 +1,17 @@
 import test from 'ava';
 import nock from 'nock';
 import {stub} from 'sinon';
-import verify from '../lib/verify';
+import proxyquire from 'proxyquire';
+import getClient from '../lib/get-client';
 import {authenticate} from './helpers/mock-github';
 
 // Save the current process.env
 const envBackup = Object.assign({}, process.env);
+
+const verify = proxyquire('../lib/verify', {
+  './get-client': (githubToken, githubUrl, githubApiPathPrefix) =>
+    getClient(githubToken, githubUrl, githubApiPathPrefix, {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}),
+});
 
 test.beforeEach(t => {
   // Delete env variables in case they are on the machine running the tests


### PR DESCRIPTION
Fix semantic-release/semantic-release#607, Fix semantic-release/semantic-release#658

Wrap the `@octokit/rest` functions used by the plugin with [p-retry](https://github.com/sindresorhus/p-retry) with the default settings:
- Retries 3 times (in addition of the first attempt) on all errors except `400`, `401` and `403`
- Min timeout of 1s
- Factor of 2 

So the calls to the same function will be done on the following timeline: 0s, 1s, 3s and 7s. If it still fails on the 4th attempt then we throw the error return by `@octokit/rest`.


