### PR TITLE
feat: throttle and retry GitHub API calls.

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -12,7 +12,7 @@ module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, errors,
     pluginConfig
   );
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
-  const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
+  const github = getClient({githubToken, githubUrl, githubApiPathPrefix});
   const body = failComment ? template(failComment)({branch, errors}) : getFailComment(branch, errors);
   const [srIssue] = await findSRIssues(github, failTitle, owner, repo);
 

--- a/lib/get-client.js
+++ b/lib/get-client.js
@@ -1,14 +1,100 @@
 const url = require('url');
-const GitHubApi = require('@octokit/rest');
+const {memoize} = require('lodash');
+const Octokit = require('@octokit/rest');
+const pRetry = require('p-retry');
+const pThrottle = require('p-throttle');
 
-module.exports = (githubToken, githubUrl, githubApiPathPrefix) => {
+/**
+ * Default exponential backoff configuration for retries.
+ */
+const DEFAULT_RETRY = {retries: 3, factor: 2, minTimeout: 1000};
+
+/**
+ * Rate limit per API endpoints.
+ *
+ * See {@link https://developer.github.com/v3/search/#rate-limit|Search API rate limit}.
+ * See {@link https://developer.github.com/v3/#rate-limiting|Rate limiting}.
+ */
+const RATE_LIMITS = {
+  search: [30, 60 * 1000],
+  core: [5000, 60 * 60 * 1000],
+};
+
+/**
+ * Http error codes for which to not retry.
+ */
+const SKIP_RETRY_CODES = [400, 401, 403];
+
+/**
+ * @typedef {Function} Throttler
+ * @param {Function} func The function to throttle.
+ * @param {Arguments} args The arguments to pass to the function to throttle.
+ */
+
+/**
+ * Create or retrieve the throller function for a given rate limit group.
+ *
+ * @param {Array} rate The rate limit group.
+ * @param {String} limit The rate limits per API endpoints.
+ * @type {Throttler} The throller function for the given rate limit group.
+ */
+const getThrottler = memoize((rate, limit) => pThrottle((func, ...args) => func(...args), ...limit[rate]));
+
+/**
+ * Create a`handler` for a `Proxy` wrapping an Octokit instance to:
+ * - Recursively wrap the child objects of the Octokit instance in a `Proxy`
+ * - Throttle and retry the Octokit instance functions
+ *
+ * @param {Object} retry The configuration to pass to `p-retry`.
+ * @param {Array} limit The rate limits per API endpoints.
+ * @param {String} endpoint The API endpoint to handle.
+ * @return {Function} The `handler` for a `Proxy` wrapping an Octokit instance.
+ */
+const handler = (retry, limit, endpoint) => ({
+  /**
+   * If the target has the property as own, determine the rate limit based on the property name and recursively wrap the value in a `Proxy`. Otherwise returns the property value.
+   *
+   * @param {Object} target The target object.
+   * @param {String} name The name of the property to get.
+   * @param {Any} receiver The `Proxy` object.
+   * @return {Any} The property value or a `Proxy` of the property value.
+   */
+  get: (target, name, receiver) =>
+    Object.prototype.hasOwnProperty.call(target, name)
+      ? new Proxy(target[name], handler(retry, limit, endpoint || name))
+      : Reflect.get(target, name, receiver),
+
+  /**
+   * Create a throlled version of the called function tehn call it and retry it if the call fails with certain error code.
+   *
+   * @param {Function} func The target function.
+   * @param {Any} that The this argument for the call.
+   * @param {Array} args The list of arguments for the call.
+   * @return {Promise<Any>} The result of the function called.
+   */
+  apply: (func, that, args) => {
+    const throttler = getThrottler(limit[endpoint] ? endpoint : 'core', limit);
+    return pRetry(async () => {
+      try {
+        return await throttler(func, ...args);
+      } catch (err) {
+        if (SKIP_RETRY_CODES.includes(err.code)) {
+          throw new pRetry.AbortError(err);
+        }
+        throw err;
+      }
+    }, retry);
+  },
+});
+
+module.exports = ({githubToken, githubUrl, githubApiPathPrefix, retry = DEFAULT_RETRY, limit = RATE_LIMITS}) => {
   const {port, protocol, hostname} = githubUrl ? url.parse(githubUrl) : {};
-  const github = new GitHubApi({
+  const github = new Octokit({
     port,
     protocol: (protocol || '').split(':')[0] || null,
     host: hostname,
     pathPrefix: githubApiPathPrefix,
   });
   github.authenticate({type: 'token', token: githubToken});
-  return github;
+  return new Proxy(github, handler(retry, limit));
 };

--- a/lib/get-client.js
+++ b/lib/get-client.js
@@ -21,6 +21,13 @@ const RATE_LIMITS = {
 };
 
 /**
+ * Global rate limit to prevent abuse.
+ *
+ * See {@link https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits|Dealing with abuse rate limits}
+ */
+const GLOBAL_RATE_LIMIT = [1, 1000];
+
+/**
  * Http error codes for which to not retry.
  */
 const SKIP_RETRY_CODES = [400, 401, 403];
@@ -32,13 +39,21 @@ const SKIP_RETRY_CODES = [400, 401, 403];
  */
 
 /**
- * Create or retrieve the throller function for a given rate limit group.
+ * Create or retrieve the throttler function for a given rate limit group.
  *
  * @param {Array} rate The rate limit group.
  * @param {String} limit The rate limits per API endpoints.
- * @type {Throttler} The throller function for the given rate limit group.
+ * @return {Throttler} The throller function for the given rate limit group.
  */
 const getThrottler = memoize((rate, limit) => pThrottle((func, ...args) => func(...args), ...limit[rate]));
+
+/**
+ * Create the global throttler function to comply with GitHub abuse prevention recommandations.
+ *
+ * @param {Array} globalLimit The global rate limit.
+ * @return {Throttler} The throller function for the global rate limit.
+ */
+const getGlobalThrottler = globalLimit => pThrottle((func, ...args) => func(...args), ...globalLimit);
 
 /**
  * Create a`handler` for a `Proxy` wrapping an Octokit instance to:
@@ -48,9 +63,10 @@ const getThrottler = memoize((rate, limit) => pThrottle((func, ...args) => func(
  * @param {Object} retry The configuration to pass to `p-retry`.
  * @param {Array} limit The rate limits per API endpoints.
  * @param {String} endpoint The API endpoint to handle.
+ * @param {Throttler} globalThrottler The throller function for the global rate limit.
  * @return {Function} The `handler` for a `Proxy` wrapping an Octokit instance.
  */
-const handler = (retry, limit, endpoint) => ({
+const handler = (retry, limit, globalThrottler, endpoint) => ({
   /**
    * If the target has the property as own, determine the rate limit based on the property name and recursively wrap the value in a `Proxy`. Otherwise returns the property value.
    *
@@ -61,7 +77,7 @@ const handler = (retry, limit, endpoint) => ({
    */
   get: (target, name, receiver) =>
     Object.prototype.hasOwnProperty.call(target, name)
-      ? new Proxy(target[name], handler(retry, limit, endpoint || name))
+      ? new Proxy(target[name], handler(retry, limit, globalThrottler, endpoint || name))
       : Reflect.get(target, name, receiver),
 
   /**
@@ -74,9 +90,10 @@ const handler = (retry, limit, endpoint) => ({
    */
   apply: (func, that, args) => {
     const throttler = getThrottler(limit[endpoint] ? endpoint : 'core', limit);
+
     return pRetry(async () => {
       try {
-        return await throttler(func, ...args);
+        return await globalThrottler((func, ...args) => throttler(func, ...args), func, ...args);
       } catch (err) {
         if (SKIP_RETRY_CODES.includes(err.code)) {
           throw new pRetry.AbortError(err);
@@ -87,7 +104,14 @@ const handler = (retry, limit, endpoint) => ({
   },
 });
 
-module.exports = ({githubToken, githubUrl, githubApiPathPrefix, retry = DEFAULT_RETRY, limit = RATE_LIMITS}) => {
+module.exports = ({
+  githubToken,
+  githubUrl,
+  githubApiPathPrefix,
+  retry = DEFAULT_RETRY,
+  limit = RATE_LIMITS,
+  globalLimit = GLOBAL_RATE_LIMIT,
+}) => {
   const {port, protocol, hostname} = githubUrl ? url.parse(githubUrl) : {};
   const github = new Octokit({
     port,
@@ -96,5 +120,5 @@ module.exports = ({githubToken, githubUrl, githubApiPathPrefix, retry = DEFAULT_
     pathPrefix: githubApiPathPrefix,
   });
   github.authenticate({type: 'token', token: githubToken});
-  return new Proxy(github, handler(retry, limit));
+  return new Proxy(github, handler(retry, limit, getGlobalThrottler(globalLimit)));
 };

--- a/lib/glob-assets.js
+++ b/lib/glob-assets.js
@@ -1,49 +1,50 @@
 const {basename} = require('path');
 const {isPlainObject, castArray, uniqWith} = require('lodash');
-const pReduce = require('p-reduce');
 const globby = require('globby');
 const debug = require('debug')('semantic-release:github');
 
 module.exports = async assets =>
   uniqWith(
-    (await pReduce(
-      assets,
-      async (result, asset) => {
-        // Wrap single glob definition in Array
-        const glob = castArray(isPlainObject(asset) ? asset.path : asset);
-        // Skip solo negated pattern (avoid to include every non js file with `!**/*.js`)
-        if (glob.length <= 1 && glob[0].startsWith('!')) {
-          debug(
-            'skipping the negated glob %o as its alone in its group and would retrieve a large amount of files ',
-            glob[0]
-          );
-          return result;
-        }
-        const globbed = await globby(glob, {expandDirectories: true, gitignore: false, dot: true});
-        if (isPlainObject(asset)) {
-          if (globbed.length > 1) {
-            // If asset is an Object with a glob the `path` property that resolve to multiple files,
-            // Output an Object definition for each file matched and set each one with:
-            // - `path` of the matched file
-            // - `name` based on the actual file name (to avoid assets with duplicate `name`)
-            // - other properties of the original asset definition
-            return [...result, ...globbed.map(file => Object.assign({}, asset, {path: file, name: basename(file)}))];
-          }
-          // If asset is an Object, output an Object definition with:
-          // - `path` of the matched file if there is one, or the original `path` definition (will be considered as a missing file)
-          // - other properties of the original asset definition
-          return [...result, Object.assign({}, asset, {path: globbed[0] || asset.path})];
-        }
-        if (globbed.length > 0) {
-          // If asset is a String definition, output each files matched
-          return [...result, ...globbed];
-        }
-        // If asset is a String definition but no match is found, output the elements of the original glob (each one will be considered as a missing file)
-        return [...result, ...glob];
-      },
-      []
-      // Sort with Object first, to prioritize Object definition over Strings in dedup
-    )).sort(asset => !isPlainObject(asset)),
+    []
+      .concat(
+        ...(await Promise.all(
+          assets.map(async asset => {
+            // Wrap single glob definition in Array
+            const glob = castArray(isPlainObject(asset) ? asset.path : asset);
+            // Skip solo negated pattern (avoid to include every non js file with `!**/*.js`)
+            if (glob.length <= 1 && glob[0].startsWith('!')) {
+              debug(
+                'skipping the negated glob %o as its alone in its group and would retrieve a large amount of files ',
+                glob[0]
+              );
+              return [];
+            }
+            const globbed = await globby(glob, {expandDirectories: true, gitignore: false, dot: true});
+            if (isPlainObject(asset)) {
+              if (globbed.length > 1) {
+                // If asset is an Object with a glob the `path` property that resolve to multiple files,
+                // Output an Object definition for each file matched and set each one with:
+                // - `path` of the matched file
+                // - `name` based on the actual file name (to avoid assets with duplicate `name`)
+                // - other properties of the original asset definition
+                return globbed.map(file => Object.assign({}, asset, {path: file, name: basename(file)}));
+              }
+              // If asset is an Object, output an Object definition with:
+              // - `path` of the matched file if there is one, or the original `path` definition (will be considered as a missing file)
+              // - other properties of the original asset definition
+              return Object.assign({}, asset, {path: globbed[0] || asset.path});
+            }
+            if (globbed.length > 0) {
+              // If asset is a String definition, output each files matched
+              return globbed;
+            }
+            // If asset is a String definition but no match is found, output the elements of the original glob (each one will be considered as a missing file)
+            return glob;
+          })
+          // Sort with Object first, to prioritize Object definition over Strings in dedup
+        ))
+      )
+      .sort(asset => !isPlainObject(asset)),
     // Compare `path` property if Object definition, value itself if String
     (a, b) => (isPlainObject(a) ? a.path : a) === (isPlainObject(b) ? b.path : b)
   );

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,7 +2,6 @@ const {basename, extname} = require('path');
 const {stat, readFile} = require('fs-extra');
 const {isPlainObject} = require('lodash');
 const parseGithubUrl = require('parse-github-url');
-const pReduce = require('p-reduce');
 const mime = require('mime');
 const debug = require('debug')('semantic-release:github');
 const globAssets = require('./glob-assets.js');
@@ -26,43 +25,45 @@ module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, nextRel
   if (assets && assets.length > 0) {
     const globbedAssets = await globAssets(assets);
     debug('globed assets: %o', globbedAssets);
-    // Make requests serially to avoid hitting the rate limit (https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)
-    await pReduce(globbedAssets, async (_, asset) => {
-      const filePath = isPlainObject(asset) ? asset.path : asset;
-      let file;
 
-      try {
-        file = await stat(filePath);
-      } catch (err) {
-        logger.error('The asset %s cannot be read, and will be ignored.', filePath);
-        return;
-      }
-      if (!file || !file.isFile()) {
-        logger.error('The asset %s is not a file, and will be ignored.', filePath);
-        return;
-      }
+    await Promise.all(
+      globbedAssets.map(async asset => {
+        const filePath = isPlainObject(asset) ? asset.path : asset;
+        let file;
 
-      const fileName = asset.name || basename(filePath);
-      const upload = {
-        owner,
-        repo,
-        url: uploadUrl,
-        file: await readFile(filePath),
-        contentType: mime.getType(extname(fileName)) || 'text/plain',
-        contentLength: file.size,
-        name: fileName,
-      };
+        try {
+          file = await stat(filePath);
+        } catch (err) {
+          logger.error('The asset %s cannot be read, and will be ignored.', filePath);
+          return;
+        }
+        if (!file || !file.isFile()) {
+          logger.error('The asset %s is not a file, and will be ignored.', filePath);
+          return;
+        }
 
-      debug('file path: %o', filePath);
-      debug('file name: %o', fileName);
+        const fileName = asset.name || basename(filePath);
+        const upload = {
+          owner,
+          repo,
+          url: uploadUrl,
+          file: await readFile(filePath),
+          contentType: mime.getType(extname(fileName)) || 'text/plain',
+          contentLength: file.size,
+          name: fileName,
+        };
 
-      if (isPlainObject(asset) && asset.label) {
-        upload.label = asset.label;
-      }
+        debug('file path: %o', filePath);
+        debug('file name: %o', fileName);
 
-      const {data: {browser_download_url: downloadUrl}} = await github.repos.uploadAsset(upload);
-      logger.log('Published file %s', downloadUrl);
-    });
+        if (isPlainObject(asset) && asset.label) {
+          upload.label = asset.label;
+        }
+
+        const {data: {browser_download_url: downloadUrl}} = await github.repos.uploadAsset(upload);
+        logger.log('Published file %s', downloadUrl);
+      })
+    );
   }
 
   return {url, name: 'GitHub release'};

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -44,8 +44,6 @@ module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, nextRel
 
         const fileName = asset.name || basename(filePath);
         const upload = {
-          owner,
-          repo,
           url: uploadUrl,
           file: await readFile(filePath),
           contentType: mime.getType(extname(fileName)) || 'text/plain',

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -12,7 +12,7 @@ const getClient = require('./get-client');
 module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, nextRelease: {gitTag, notes}, logger}) => {
   const {githubToken, githubUrl, githubApiPathPrefix, assets} = resolveConfig(pluginConfig);
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
-  const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
+  const github = getClient({githubToken, githubUrl, githubApiPathPrefix});
   const release = {owner, repo, tag_name: gitTag, name: gitTag, target_commitish: branch, body: notes}; // eslint-disable-line camelcase
 
   debug('release owner: %o', owner);

--- a/lib/success.js
+++ b/lib/success.js
@@ -16,7 +16,7 @@ module.exports = async (
 ) => {
   const {githubToken, githubUrl, githubApiPathPrefix, successComment, failTitle} = resolveConfig(pluginConfig);
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
-  const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
+  const github = getClient({githubToken, githubUrl, githubApiPathPrefix});
   const releaseInfos = releases.filter(release => Boolean(release.name));
 
   const prs = await pReduce(

--- a/lib/success.js
+++ b/lib/success.js
@@ -1,6 +1,5 @@
 const {uniqBy, template} = require('lodash');
 const parseGithubUrl = require('parse-github-url');
-const pReduce = require('p-reduce');
 const AggregateError = require('aggregate-error');
 const issueParser = require('issue-parser')('github');
 const debug = require('debug')('semantic-release:github');
@@ -19,13 +18,13 @@ module.exports = async (
   const github = getClient({githubToken, githubUrl, githubApiPathPrefix});
   const releaseInfos = releases.filter(release => Boolean(release.name));
 
-  const prs = await pReduce(
-    getSearchQueries(`repo:${owner}/${repo}+type:pr`, commits.map(commit => commit.hash)),
-    async (prs, q) => {
-      const {data: {items}} = await github.search.issues({q});
-      return [...prs, ...items];
-    },
-    []
+  const prs = [].concat(
+    ...(await Promise.all(
+      getSearchQueries(`repo:${owner}/${repo}+type:pr`, commits.map(commit => commit.hash)).map(async q => {
+        const {data: {items}} = await github.search.issues({q});
+        return items;
+      })
+    ))
   );
 
   debug('found pull requests: %O', prs.map(pr => pr.number));
@@ -46,40 +45,43 @@ module.exports = async (
 
   const errors = [];
 
-  // Make requests serially to avoid hitting the rate limit (https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)
-  await pReduce([...prs, ...issues], async (_, issue) => {
-    const body = successComment
-      ? template(successComment)({branch, lastRelease, commits, nextRelease, releases, issue})
-      : getSuccessComment(issue, releaseInfos, nextRelease);
-    try {
-      const comment = {owner, repo, number: issue.number, body};
-      debug('create comment: %O', comment);
-      const {data: {html_url: url}} = await github.issues.createComment(comment);
-      logger.log('Added comment to issue #%d: %s', issue.number, url);
-    } catch (err) {
-      errors.push(err);
-      logger.error('Failed to add a comment to the issue #%d.', issue.number);
-      // Don't throw right away and continue to update other issues
-    }
-  });
+  await Promise.all(
+    [...prs, ...issues].map(async issue => {
+      const body = successComment
+        ? template(successComment)({branch, lastRelease, commits, nextRelease, releases, issue})
+        : getSuccessComment(issue, releaseInfos, nextRelease);
+      try {
+        const comment = {owner, repo, number: issue.number, body};
+        debug('create comment: %O', comment);
+        const {data: {html_url: url}} = await github.issues.createComment(comment);
+        logger.log('Added comment to issue #%d: %s', issue.number, url);
+      } catch (err) {
+        errors.push(err);
+        logger.error('Failed to add a comment to the issue #%d.', issue.number);
+        // Don't throw right away and continue to update other issues
+      }
+    })
+  );
 
   const srIssues = await findSRIssues(github, failTitle, owner, repo);
 
   debug('found semantic-release issues: %O', srIssues);
 
-  await pReduce(srIssues, async (_, issue) => {
-    debug('close issue: %O', issue);
-    try {
-      const updateIssue = {owner, repo, number: issue.number, state: 'closed'};
-      debug('closing issue: %O', updateIssue);
-      const {data: {html_url: url}} = await github.issues.edit(updateIssue);
-      logger.log('Closed issue #%d: %s.', issue.number, url);
-    } catch (err) {
-      errors.push(err);
-      logger.error('Failed to close the issue #%d.', issue.number);
-      // Don't throw right away and continue to close other issues
-    }
-  });
+  await Promise.all(
+    srIssues.map(async issue => {
+      debug('close issue: %O', issue);
+      try {
+        const updateIssue = {owner, repo, number: issue.number, state: 'closed'};
+        debug('closing issue: %O', updateIssue);
+        const {data: {html_url: url}} = await github.issues.edit(updateIssue);
+        logger.log('Closed issue #%d: %s.', issue.number, url);
+      } catch (err) {
+        errors.push(err);
+        logger.error('Failed to close the issue #%d.', issue.number);
+        // Don't throw right away and continue to close other issues
+      }
+    })
+  );
 
   if (errors.length > 0) {
     throw new AggregateError(errors);

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -74,7 +74,7 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
   }
 
   if (githubToken) {
-    const github = getClient(githubToken, githubUrl, githubApiPathPrefix);
+    const github = getClient({githubToken, githubUrl, githubApiPathPrefix});
 
     try {
       const {data: {permissions: {push}}} = await github.repos.get({repo, owner});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "issue-parser": "^1.0.1",
     "lodash": "^4.17.4",
     "mime": "^2.0.3",
-    "p-reduce": "^1.0.0",
     "p-retry": "^1.0.0",
     "p-throttle": "^1.1.0",
     "parse-github-url": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "lodash": "^4.17.4",
     "mime": "^2.0.3",
     "p-reduce": "^1.0.0",
+    "p-retry": "^1.0.0",
+    "p-throttle": "^1.1.0",
     "parse-github-url": "^1.0.1",
     "url-join": "^4.0.0"
   },
@@ -37,6 +39,7 @@
     "cz-conventional-changelog": "^2.0.0",
     "nock": "^9.1.0",
     "nyc": "^11.2.1",
+    "proxyquire": "^1.8.0",
     "semantic-release": "^12.2.2",
     "sinon": "^4.0.0",
     "tempy": "^0.2.1",

--- a/test/fail.test.js
+++ b/test/fail.test.js
@@ -11,7 +11,8 @@ import {authenticate} from './helpers/mock-github';
 /* eslint camelcase: ["error", {properties: "never"}] */
 
 const fail = proxyquire('../lib/fail', {
-  './get-client': conf => getClient({...conf, ...{retry: {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}}}),
+  './get-client': conf =>
+    getClient({...conf, ...{retry: {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}, globalLimit: [99, 1]}}),
 });
 
 // Save the current process.env
@@ -66,7 +67,7 @@ test.serial('Open a new issue with the list of errors', async t => {
 
   await fail(pluginConfig, {options, errors, logger: t.context.logger});
 
-  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
 });
 
@@ -112,7 +113,7 @@ test.serial('Open a new issue with the list of errors, retrying 4 times', async 
 
   await fail(pluginConfig, {options, errors, logger: t.context.logger});
 
-  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
 });
 
@@ -145,7 +146,7 @@ test.serial('Open a new issue with the list of errors and custom title and comme
 
   await fail(pluginConfig, {options, errors, logger: t.context.logger});
 
-  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
 });
 
@@ -178,7 +179,7 @@ test.serial('Open a new issue with assignees and the list of errors', async t =>
 
   await fail(pluginConfig, {options, errors, logger: t.context.logger});
 
-  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
 });
 
@@ -210,7 +211,7 @@ test.serial('Open a new issue without labels and the list of errors', async t =>
 
   await fail(pluginConfig, {options, errors, logger: t.context.logger});
 
-  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
 });
 
@@ -245,7 +246,7 @@ test.serial('Update the first existing issue with the list of errors', async t =
 
   await fail(pluginConfig, {options, errors, logger: t.context.logger});
 
-  t.deepEqual(t.context.log.args[0], ['Found existing semantic-release issue #%d.', 2]);
-  t.deepEqual(t.context.log.args[1], ['Added comment to issue #%d: %s.', 2, 'https://github.com/issues/2']);
+  t.true(t.context.log.calledWith('Found existing semantic-release issue #%d.', 2));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s.', 2, 'https://github.com/issues/2'));
   t.true(github.isDone());
 });

--- a/test/fail.test.js
+++ b/test/fail.test.js
@@ -2,12 +2,17 @@ import {escape} from 'querystring';
 import test from 'ava';
 import nock from 'nock';
 import {stub} from 'sinon';
+import proxyquire from 'proxyquire';
 import SemanticReleaseError from '@semantic-release/error';
 import ISSUE_ID from '../lib/definitions/sr-issue-id';
-import fail from '../lib/fail';
+import getClient from '../lib/get-client';
 import {authenticate} from './helpers/mock-github';
 
 /* eslint camelcase: ["error", {properties: "never"}] */
+
+const fail = proxyquire('../lib/fail', {
+  './get-client': conf => getClient({...conf, ...{retry: {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}}}),
+});
 
 // Save the current process.env
 const envBackup = Object.assign({}, process.env);
@@ -52,6 +57,52 @@ test.serial('Open a new issue with the list of errors', async t => {
       )}+${escape(failTitle)}`
     )
     .reply(200, {items: []})
+    .post(`/repos/${owner}/${repo}/issues`, {
+      title: failTitle,
+      body: /---\n\n### Error message 1\n\nError 1 details\n\n---\n\n### Error message 2\n\nError 2 details\n\n---\n\n### Error message 3\n\nError 3 details\n\n---/,
+      labels: ['semantic-release'],
+    })
+    .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
+
+  await fail(pluginConfig, {options, errors, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args[0], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(github.isDone());
+});
+
+test.serial('Open a new issue with the list of errors, retrying 4 times', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'The automated release is failing 🚨';
+  const pluginConfig = {failTitle};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const errors = [
+    new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
+    new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
+    new SemanticReleaseError('Error message 3', 'ERR3', 'Error 3 details'),
+  ];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${escape('in:title')}+${escape(`repo:${owner}/${repo}`)}+${escape('type:issue')}+${escape(
+        'state:open'
+      )}+${escape(failTitle)}`
+    )
+    .times(3)
+    .reply(404)
+    .get(
+      `/search/issues?q=${escape('in:title')}+${escape(`repo:${owner}/${repo}`)}+${escape('type:issue')}+${escape(
+        'state:open'
+      )}+${escape(failTitle)}`
+    )
+    .reply(200, {items: []})
+    .post(`/repos/${owner}/${repo}/issues`, {
+      title: failTitle,
+      body: /---\n\n### Error message 1\n\nError 1 details\n\n---\n\n### Error message 2\n\nError 2 details\n\n---\n\n### Error message 3\n\nError 3 details\n\n---/,
+      labels: ['semantic-release'],
+    })
+    .times(3)
+    .reply(500)
     .post(`/repos/${owner}/${repo}/issues`, {
       title: failTitle,
       body: /---\n\n### Error message 1\n\nError 1 details\n\n---\n\n### Error message 2\n\nError 2 details\n\n---\n\n### Error message 3\n\nError 3 details\n\n---/,

--- a/test/find-sr-issue.test.js
+++ b/test/find-sr-issue.test.js
@@ -11,6 +11,8 @@ import {authenticate} from './helpers/mock-github';
 
 // Save the current process.env
 const envBackup = Object.assign({}, process.env);
+const githubToken = 'github_token';
+const client = getClient({githubToken, retry: {retries: 3, factor: 2, minTimeout: 1, maxTimeout: 1}});
 
 test.beforeEach(t => {
   // Delete env variables in case they are on the machine running the tests
@@ -51,7 +53,7 @@ test.serial('Filter out issues without ID', async t => {
     )
     .reply(200, {items: issues});
 
-  const srIssues = await findSRIssues(getClient(githubToken), title, owner, repo);
+  const srIssues = await findSRIssues(client, title, owner, repo);
 
   t.deepEqual(srIssues, [
     {number: 2, body: 'Issue 2 body\n\n<!-- semantic-release:github -->', title},
@@ -75,7 +77,7 @@ test.serial('Return empty array if not issues found', async t => {
     )
     .reply(200, {items: issues});
 
-  const srIssues = await findSRIssues(getClient(githubToken), title, owner, repo);
+  const srIssues = await findSRIssues(client, title, owner, repo);
 
   t.deepEqual(srIssues, []);
 
@@ -96,9 +98,45 @@ test.serial('Return empty array if not issues has matching ID', async t => {
     )
     .reply(200, {items: issues});
 
-  const srIssues = await findSRIssues(getClient(githubToken), title, owner, repo);
+  const srIssues = await findSRIssues(client, title, owner, repo);
 
   t.deepEqual(srIssues, []);
+  t.true(github.isDone());
+});
 
+test.serial('Retries 4 times', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const title = 'The automated release is failing :rotating_light:';
+  const github = authenticate({githubToken})
+    .get(
+      `/search/issues?q=${escape('in:title')}+${escape(`repo:${owner}/${repo}`)}+${escape('type:issue')}+${escape(
+        'state:open'
+      )}+${escape(title)}`
+    )
+    .times(4)
+    .reply(422);
+
+  const error = await t.throws(findSRIssues(client, title, owner, repo));
+
+  t.is(error.code, 422);
+  t.true(github.isDone());
+});
+
+test.serial('Do not retry on 401 error', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const title = 'The automated release is failing :rotating_light:';
+  const github = authenticate({githubToken})
+    .get(
+      `/search/issues?q=${escape('in:title')}+${escape(`repo:${owner}/${repo}`)}+${escape('type:issue')}+${escape(
+        'state:open'
+      )}+${escape(title)}`
+    )
+    .reply(401);
+
+  const error = await t.throws(findSRIssues(client, title, owner, repo));
+
+  t.is(error.code, 401);
   t.true(github.isDone());
 });

--- a/test/find-sr-issue.test.js
+++ b/test/find-sr-issue.test.js
@@ -12,7 +12,11 @@ import {authenticate} from './helpers/mock-github';
 // Save the current process.env
 const envBackup = Object.assign({}, process.env);
 const githubToken = 'github_token';
-const client = getClient({githubToken, retry: {retries: 3, factor: 2, minTimeout: 1, maxTimeout: 1}});
+const client = getClient({
+  githubToken,
+  retry: {retries: 3, factor: 2, minTimeout: 1, maxTimeout: 1},
+  globalLimit: [99, 1],
+});
 
 test.beforeEach(t => {
   // Delete env variables in case they are on the machine running the tests

--- a/test/get-client.test.js
+++ b/test/get-client.test.js
@@ -1,0 +1,81 @@
+import test from 'ava';
+import {isFunction, isPlainObject, inRange} from 'lodash';
+import {stub} from 'sinon';
+import proxyquire from 'proxyquire';
+import getClient from '../lib/get-client';
+
+test('Wrap Octokit in a proxy', t => {
+  const github = getClient({githubToken: 'github_token'});
+
+  t.true(Object.prototype.hasOwnProperty.call(github, 'repos'));
+  t.true(isPlainObject(github.repos));
+  t.true(Object.prototype.hasOwnProperty.call(github.repos, 'createRelease'));
+  t.true(isFunction(github.repos.createRelease));
+
+  t.true(Object.prototype.hasOwnProperty.call(github, 'search'));
+  t.true(isPlainObject(github.search));
+  t.true(Object.prototype.hasOwnProperty.call(github.search, 'issues'));
+  t.true(isFunction(github.search.issues));
+
+  t.falsy(github.unknown);
+});
+
+test('Use the same throttler for endpoints in the same rate limit group', async t => {
+  const createRelease = stub().callsFake(async () => Date.now());
+  const createComment = stub().callsFake(async () => Date.now());
+  const issues = stub().callsFake(async () => Date.now());
+  const octokit = {repos: {createRelease}, issues: {createComment}, search: {issues}, authenticate: stub()};
+  const searchRate = 300;
+  const coreRate = 150;
+  const github = proxyquire('../lib/get-client', {'@octokit/rest': stub().returns(octokit)})({
+    limit: {search: [1, searchRate], core: [1, coreRate]},
+  });
+
+  const a = await github.repos.createRelease();
+  const b = await github.issues.createComment();
+  const c = await github.repos.createRelease();
+  const d = await github.issues.createComment();
+  const e = await github.search.issues();
+  const f = await github.search.issues();
+
+  // `issues.createComment` should be called `coreRate` ms after `repos.createRelease`
+  t.true(inRange(b - a, coreRate - 50, coreRate + 50));
+  // `repos.createRelease` should be called `coreRate` ms after `issues.createComment`
+  t.true(inRange(c - b, coreRate - 50, coreRate + 50));
+  // `issues.createComment` should be called `coreRate` ms after `repos.createRelease`
+  t.true(inRange(d - c, coreRate - 50, coreRate + 50));
+
+  // The first search should be called immediatly as it uses a different throttler
+  t.true(inRange(e - d, -50, 50));
+  // The second search should be called only after `searchRate` ms
+  t.true(inRange(f - e, searchRate - 50, searchRate + 50));
+});
+
+test('Use the same throttler when retrying', async t => {
+  const createRelease = stub().callsFake(async () => {
+    const err = new Error();
+    err.time = Date.now();
+    err.code = 404;
+    throw err;
+  });
+
+  const octokit = {repos: {createRelease}, authenticate: stub()};
+  const coreRate = 200;
+  const github = proxyquire('../lib/get-client', {'@octokit/rest': stub().returns(octokit)})({
+    limit: {core: [1, coreRate]},
+    retry: {retries: 3, factor: 1, minTimeout: 1},
+  });
+
+  await t.throws(github.repos.createRelease());
+  t.is(createRelease.callCount, 4);
+
+  const {time: a} = await t.throws(createRelease.getCall(0).returnValue);
+  const {time: b} = await t.throws(createRelease.getCall(1).returnValue);
+  const {time: c} = await t.throws(createRelease.getCall(2).returnValue);
+  const {time: d} = await t.throws(createRelease.getCall(3).returnValue);
+
+  // Each retry should be done after `coreRate` ms
+  t.true(inRange(b - a, coreRate - 50, coreRate + 50));
+  t.true(inRange(c - b, coreRate - 50, coreRate + 50));
+  t.true(inRange(d - c, coreRate - 50, coreRate + 50));
+});

--- a/test/glob-assets.test.js
+++ b/test/glob-assets.test.js
@@ -8,47 +8,50 @@ test('Retrieve file from single path', async t => {
 });
 
 test('Retrieve multiple files from path', async t => {
-  const globbedAssets = await globAssets(['test/fixtures/upload.txt', 'test/fixtures/upload_other.txt']);
+  const globbedAssets = (await globAssets(['test/fixtures/upload.txt', 'test/fixtures/upload_other.txt'])).sort();
 
-  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt']);
+  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt'].sort());
 });
 
 test('Include missing files as defined, using Object definition', async t => {
-  const globbedAssets = await globAssets([
+  const globbedAssets = (await globAssets([
     'test/fixtures/upload.txt',
     {path: 'test/fixtures/miss*.txt', label: 'Missing'},
-  ]);
+  ])).sort();
 
-  t.deepEqual(globbedAssets, [{path: 'test/fixtures/miss*.txt', label: 'Missing'}, 'test/fixtures/upload.txt']);
+  t.deepEqual(globbedAssets, ['test/fixtures/upload.txt', {path: 'test/fixtures/miss*.txt', label: 'Missing'}].sort());
 });
 
 test('Retrieve multiple files from Object', async t => {
-  const globbedAssets = await globAssets([
+  const globbedAssets = (await globAssets([
     {path: 'test/fixtures/upload.txt', name: 'upload_name', label: 'Upload label'},
     'test/fixtures/upload_other.txt',
-  ]);
+  ])).sort();
 
-  t.deepEqual(globbedAssets, [
-    {path: 'test/fixtures/upload.txt', name: 'upload_name', label: 'Upload label'},
-    'test/fixtures/upload_other.txt',
-  ]);
+  t.deepEqual(
+    globbedAssets,
+    [
+      {path: 'test/fixtures/upload.txt', name: 'upload_name', label: 'Upload label'},
+      'test/fixtures/upload_other.txt',
+    ].sort()
+  );
 });
 
 test('Retrieve multiple files without duplicates', async t => {
-  const globbedAssets = await globAssets([
+  const globbedAssets = (await globAssets([
     'test/fixtures/upload_other.txt',
     'test/fixtures/upload.txt',
     'test/fixtures/upload_other.txt',
     'test/fixtures/upload.txt',
     'test/fixtures/upload.txt',
     'test/fixtures/upload_other.txt',
-  ]);
+  ])).sort();
 
-  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt']);
+  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt'].sort());
 });
 
 test('Favor Object over String values when removing duplicates', async t => {
-  const globbedAssets = await globAssets([
+  const globbedAssets = (await globAssets([
     'test/fixtures/upload_other.txt',
     'test/fixtures/upload.txt',
     {path: 'test/fixtures/upload.txt', name: 'upload_name'},
@@ -56,11 +59,14 @@ test('Favor Object over String values when removing duplicates', async t => {
     {path: 'test/fixtures/upload_other.txt', name: 'upload_other_name'},
     'test/fixtures/upload.txt',
     'test/fixtures/upload_other.txt',
-  ]);
-  t.deepEqual(globbedAssets, [
-    {path: 'test/fixtures/upload.txt', name: 'upload_name'},
-    {path: 'test/fixtures/upload_other.txt', name: 'upload_other_name'},
-  ]);
+  ])).sort();
+  t.deepEqual(
+    globbedAssets,
+    [
+      {path: 'test/fixtures/upload.txt', name: 'upload_name'},
+      {path: 'test/fixtures/upload_other.txt', name: 'upload_other_name'},
+    ].sort()
+  );
 });
 
 test('Retrieve file from single glob', async t => {
@@ -70,36 +76,41 @@ test('Retrieve file from single glob', async t => {
 });
 
 test('Retrieve multiple files from single glob', async t => {
-  const globbedAssets = await globAssets(['test/fixtures/*.txt']);
+  const globbedAssets = (await globAssets(['test/fixtures/*.txt'])).sort();
 
-  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt']);
+  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt'].sort());
 });
 
 test('Accept glob array with one value', async t => {
-  const globbedAssets = await globAssets([['test/fixtures/*load.txt'], ['test/fixtures/*_other.txt']]);
+  const globbedAssets = (await globAssets([['test/fixtures/*load.txt'], ['test/fixtures/*_other.txt']])).sort();
 
-  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt']);
+  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt'].sort());
 });
 
 test('Include globs that resolve to no files as defined', async t => {
-  const globbedAssets = await globAssets([['test/fixtures/upload.txt', '!test/fixtures/upload.txt']]);
+  const globbedAssets = (await globAssets([['test/fixtures/upload.txt', '!test/fixtures/upload.txt']])).sort();
 
-  t.deepEqual(globbedAssets, ['!test/fixtures/upload.txt', 'test/fixtures/upload.txt']);
+  t.deepEqual(globbedAssets, ['!test/fixtures/upload.txt', 'test/fixtures/upload.txt'].sort());
 });
 
 test('Accept glob array with one value for missing files', async t => {
-  const globbedAssets = await globAssets([['test/fixtures/*missing.txt'], ['test/fixtures/*_other.txt']]);
+  const globbedAssets = (await globAssets([['test/fixtures/*missing.txt'], ['test/fixtures/*_other.txt']])).sort();
 
-  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/*missing.txt']);
+  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/*missing.txt'].sort());
 });
 
 test('Replace name by filename for Object that match multiple files', async t => {
-  const globbedAssets = await globAssets([{path: 'test/fixtures/*.txt', name: 'upload_name', label: 'Upload label'}]);
+  const globbedAssets = (await globAssets([
+    {path: 'test/fixtures/*.txt', name: 'upload_name', label: 'Upload label'},
+  ])).sort();
 
-  t.deepEqual(globbedAssets, [
-    {path: 'test/fixtures/upload.txt', name: 'upload.txt', label: 'Upload label'},
-    {path: 'test/fixtures/upload_other.txt', name: 'upload_other.txt', label: 'Upload label'},
-  ]);
+  t.deepEqual(
+    globbedAssets,
+    [
+      {path: 'test/fixtures/upload.txt', name: 'upload.txt', label: 'Upload label'},
+      {path: 'test/fixtures/upload_other.txt', name: 'upload_other.txt', label: 'Upload label'},
+    ].sort()
+  );
 });
 
 test('Include dotfiles', async t => {
@@ -127,9 +138,12 @@ test('Accept negated globs', async t => {
 });
 
 test('Expand directories', async t => {
-  const globbedAssets = await globAssets([['test/fixtures']]);
+  const globbedAssets = (await globAssets([['test/fixtures']])).sort();
 
-  t.deepEqual(globbedAssets, ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt', 'test/fixtures/.dotfile']);
+  t.deepEqual(
+    globbedAssets,
+    ['test/fixtures/upload_other.txt', 'test/fixtures/upload.txt', 'test/fixtures/.dotfile'].sort()
+  );
 });
 
 test('Include empty directory as defined', async t => {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -171,8 +171,8 @@ test.serial('Publish a release with an array of assets', async t => {
   t.is(result.url, releaseUrl);
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
   t.deepEqual(t.context.log.args[1], ['Published GitHub release: %s', releaseUrl]);
-  t.deepEqual(t.context.log.args[2], ['Published file %s', assetUrl]);
-  t.deepEqual(t.context.log.args[3], ['Published file %s', otherAssetUrl]);
+  t.true(t.context.log.calledWith('Published file %s', otherAssetUrl));
+  t.true(t.context.log.calledWith('Published file %s', assetUrl));
   t.true(github.isDone());
   t.true(githubUpload1.isDone());
   t.true(githubUpload2.isDone());
@@ -209,7 +209,7 @@ test.serial('Comment on PR included in the releases', async t => {
   await t.context.m.success({failTitle}, {options, commits, nextRelease, releases, logger: t.context.logger});
 
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
-  t.deepEqual(t.context.log.args[1], ['Added comment to issue #%d: %s', 1, 'https://github.com/successcomment-1']);
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 1, 'https://github.com/successcomment-1'));
   t.true(github.isDone());
 });
 
@@ -243,7 +243,7 @@ test.serial('Open a new issue with the list of errors', async t => {
   await t.context.m.fail({failTitle}, {options, errors, logger: t.context.logger});
 
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
-  t.deepEqual(t.context.log.args[1], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
 });
 
@@ -316,8 +316,8 @@ test.serial('Verify, release and notify success', async t => {
 
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
   t.deepEqual(t.context.log.args[1], ['Published GitHub release: %s', releaseUrl]);
-  t.deepEqual(t.context.log.args[2], ['Published file %s', otherAssetUrl]);
-  t.deepEqual(t.context.log.args[3], ['Published file %s', assetUrl]);
+  t.true(t.context.log.calledWith('Published file %s', otherAssetUrl));
+  t.true(t.context.log.calledWith('Published file %s', assetUrl));
   t.true(github.isDone());
   t.true(githubUpload1.isDone());
   t.true(githubUpload2.isDone());
@@ -354,6 +354,6 @@ test.serial('Verify and notify failure', async t => {
   await t.context.m.fail({failTitle}, {options, errors, logger: t.context.logger});
 
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
-  t.deepEqual(t.context.log.args[1], ['Created issue #%d: %s.', 1, 'https://github.com/issues/1']);
+  t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
 });

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -3,11 +3,16 @@ import test from 'ava';
 import {stat} from 'fs-extra';
 import nock from 'nock';
 import {stub} from 'sinon';
+import proxyquire from 'proxyquire';
 import tempy from 'tempy';
-import publish from '../lib/publish';
+import getClient from '../lib/get-client';
 import {authenticate, upload} from './helpers/mock-github';
 
 /* eslint camelcase: ["error", {properties: "never"}] */
+
+const publish = proxyquire('../lib/publish', {
+  './get-client': conf => getClient({...conf, ...{retry: {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}}}),
+});
 
 // Save the current process.env
 const envBackup = Object.assign({}, process.env);
@@ -46,6 +51,42 @@ test.serial('Publish a release', async t => {
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
 
   const github = authenticate()
+    .post(`/repos/${owner}/${repo}/releases`, {
+      tag_name: nextRelease.gitTag,
+      target_commitish: options.branch,
+      name: nextRelease.gitTag,
+      body: nextRelease.notes,
+    })
+    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
+
+  const result = await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
+
+  t.is(result.url, releaseUrl);
+  t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
+  t.true(github.isDone());
+});
+
+test.serial('Publish a release, retrying 4 times', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
+  const nextRelease = {version: '1.0.0', gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
+  const releaseId = 1;
+  const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
+  const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
+
+  const github = authenticate()
+    .post(`/repos/${owner}/${repo}/releases`, {
+      tag_name: nextRelease.gitTag,
+      target_commitish: options.branch,
+      name: nextRelease.gitTag,
+      body: nextRelease.notes,
+    })
+    .times(3)
+    .reply(404)
     .post(`/repos/${owner}/${repo}/releases`, {
       tag_name: nextRelease.gitTag,
       target_commitish: options.branch,
@@ -181,5 +222,35 @@ test.serial('Publish a release with an array of missing assets', async t => {
     'test/fixtures/missing.txt',
   ]);
   t.deepEqual(t.context.error.args[1], ['The asset %s is not a file, and will be ignored.', emptyDirectory]);
+  t.true(github.isDone());
+});
+
+test.serial('Throw error without retries for 400 error', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const pluginConfig = {};
+  const nextRelease = {version: '1.0.0', gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+
+  const github = authenticate()
+    .post(`/repos/${owner}/${repo}/releases`, {
+      tag_name: nextRelease.gitTag,
+      target_commitish: options.branch,
+      name: nextRelease.gitTag,
+      body: nextRelease.notes,
+    })
+    .reply(404)
+    .post(`/repos/${owner}/${repo}/releases`, {
+      tag_name: nextRelease.gitTag,
+      target_commitish: options.branch,
+      name: nextRelease.gitTag,
+      body: nextRelease.notes,
+    })
+    .reply(400);
+
+  const error = await t.throws(publish(pluginConfig, {options, nextRelease, logger: t.context.logger}));
+
+  t.is(error.code, 400);
   t.true(github.isDone());
 });

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -11,7 +11,8 @@ import {authenticate} from './helpers/mock-github';
 /* eslint camelcase: ["error", {properties: "never"}] */
 
 const success = proxyquire('../lib/success', {
-  './get-client': conf => getClient({...conf, ...{retry: {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}}}),
+  './get-client': conf =>
+    getClient({...conf, ...{retry: {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}, globalLimit: [99, 1]}}),
 });
 
 // Save the current process.env
@@ -77,10 +78,10 @@ test.serial('Add comment to PRs associated with release commits and issues close
 
   await success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger});
 
-  t.deepEqual(t.context.log.args[0], ['Added comment to issue #%d: %s', 1, 'https://github.com/successcomment-1']);
-  t.deepEqual(t.context.log.args[1], ['Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2']);
-  t.deepEqual(t.context.log.args[2], ['Added comment to issue #%d: %s', 3, 'https://github.com/successcomment-3']);
-  t.deepEqual(t.context.log.args[3], ['Added comment to issue #%d: %s', 4, 'https://github.com/successcomment-4']);
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 1, 'https://github.com/successcomment-1'));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2'));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 3, 'https://github.com/successcomment-3'));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 4, 'https://github.com/successcomment-4'));
   t.true(github.isDone());
 });
 
@@ -139,12 +140,12 @@ test.serial('Make multiple search queries if necessary', async t => {
 
   await success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger});
 
-  t.deepEqual(t.context.log.args[0], ['Added comment to issue #%d: %s', 1, 'https://github.com/successcomment-1']);
-  t.deepEqual(t.context.log.args[1], ['Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2']);
-  t.deepEqual(t.context.log.args[2], ['Added comment to issue #%d: %s', 3, 'https://github.com/successcomment-3']);
-  t.deepEqual(t.context.log.args[3], ['Added comment to issue #%d: %s', 4, 'https://github.com/successcomment-4']);
-  t.deepEqual(t.context.log.args[4], ['Added comment to issue #%d: %s', 5, 'https://github.com/successcomment-5']);
-  t.deepEqual(t.context.log.args[5], ['Added comment to issue #%d: %s', 6, 'https://github.com/successcomment-6']);
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 1, 'https://github.com/successcomment-1'));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2'));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 3, 'https://github.com/successcomment-3'));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 4, 'https://github.com/successcomment-4'));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 5, 'https://github.com/successcomment-5'));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 6, 'https://github.com/successcomment-6'));
   t.true(github.isDone());
 });
 
@@ -261,10 +262,10 @@ test.serial('Ignore errors when adding comments and closing issues', async t => 
 
   t.is(error1.code, 404);
   t.is(error2.code, 500);
-  t.deepEqual(t.context.error.args[0], ['Failed to add a comment to the issue #%d.', 1]);
-  t.deepEqual(t.context.error.args[1], ['Failed to close the issue #%d.', 2]);
-  t.deepEqual(t.context.log.args[0], ['Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2']);
-  t.deepEqual(t.context.log.args[1], ['Closed issue #%d: %s.', 3, 'https://github.com/issues/3']);
+  t.true(t.context.error.calledWith('Failed to add a comment to the issue #%d.', 1));
+  t.true(t.context.error.calledWith('Failed to close the issue #%d.', 2));
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2'));
+  t.true(t.context.log.calledWith('Closed issue #%d: %s.', 3, 'https://github.com/issues/3'));
   t.true(github.isDone());
 });
 
@@ -302,8 +303,7 @@ test.serial('Close open issues when a release is successful', async t => {
     .reply(200, {html_url: 'https://github.com/issues/3'});
 
   await success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger});
-
-  t.deepEqual(t.context.log.args[0], ['Closed issue #%d: %s.', 2, 'https://github.com/issues/2']);
-  t.deepEqual(t.context.log.args[1], ['Closed issue #%d: %s.', 3, 'https://github.com/issues/3']);
+  t.true(t.context.log.calledWith('Closed issue #%d: %s.', 2, 'https://github.com/issues/2'));
+  t.true(t.context.log.calledWith('Closed issue #%d: %s.', 3, 'https://github.com/issues/3'));
   t.true(github.isDone());
 });

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -3,11 +3,16 @@ import test from 'ava';
 import {repeat} from 'lodash';
 import nock from 'nock';
 import {stub} from 'sinon';
+import proxyquire from 'proxyquire';
 import ISSUE_ID from '../lib/definitions/sr-issue-id';
-import success from '../lib/success';
+import getClient from '../lib/get-client';
 import {authenticate} from './helpers/mock-github';
 
 /* eslint camelcase: ["error", {properties: "never"}] */
+
+const success = proxyquire('../lib/success', {
+  './get-client': conf => getClient({...conf, ...{retry: {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}}}),
+});
 
 // Save the current process.env
 const envBackup = Object.assign({}, process.env);
@@ -234,6 +239,7 @@ test.serial('Ignore errors when adding comments and closing issues', async t => 
     )
     .reply(200, {items: prs})
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
+    .times(4)
     .reply(404, {})
     .post(`/repos/${owner}/${repo}/issues/2/comments`, {body: /This PR is included/})
     .reply(200, {html_url: 'https://github.com/successcomment-2'})
@@ -244,6 +250,7 @@ test.serial('Ignore errors when adding comments and closing issues', async t => 
     )
     .reply(200, {items: issues})
     .patch(`/repos/${owner}/${repo}/issues/2`, {state: 'closed'})
+    .times(4)
     .reply(500)
     .patch(`/repos/${owner}/${repo}/issues/3`, {state: 'closed'})
     .reply(200, {html_url: 'https://github.com/issues/3'});

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -9,7 +9,8 @@ import {authenticate} from './helpers/mock-github';
 const envBackup = Object.assign({}, process.env);
 
 const verify = proxyquire('../lib/verify', {
-  './get-client': conf => getClient({...conf, ...{retry: {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}}}),
+  './get-client': conf =>
+    getClient({...conf, ...{retry: {retries: 3, factor: 1, minTimeout: 1, maxTimeout: 1}, globalLimit: [99, 1]}}),
 });
 
 test.beforeEach(t => {


### PR DESCRIPTION
Fix #37, Fix semantic-release/semantic-release#607, Fix semantic-release/semantic-release#658.

[Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) based implementation to retry and throttle the GitHub client API calls.

The implementation:
- Throttle the calls per limit rate group (The GitHub API has different limit rate for the `search` endpoints and core endpoints) => All calls to core endpoints share the same rate limit.
- Memoize the throttler function to instantiated at most one throttler per limit rate group
- Retry the calls and throttle each retries based on the rate limit group
- Do not modify the Octokit instance
- So not preemptively wrap the Octokit instance functions => Only the called function are intercepted and throttled/retried

In addition it adds a global throttler to limit request to 1 per second per GitHub recommendations [Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits):
> If you're making a large number of POST, PATCH, PUT, or DELETE requests for a single user or client ID, wait at least one second between each request.