### PR TITLE
Default octokit protocol option to undefined

### DIFF
--- a/lib/get-client.js
+++ b/lib/get-client.js
@@ -104,7 +104,7 @@ module.exports = ({
   const {port, protocol, hostname} = githubUrl ? url.parse(githubUrl) : {};
   const github = new Octokit({
     port,
-    protocol: (protocol || '').split(':')[0] || null,
+    protocol: (protocol || '').split(':')[0] || undefined,
     host: hostname,
     pathPrefix: githubApiPathPrefix,
   });


### PR DESCRIPTION
`null` does not get overwritten by _.defaults which `@octokit/rest` v15+ is using