### PR TITLE
Filter out issues/PRs in which to comment on success

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -20,7 +20,7 @@ module.exports = async (
 
   const prs = [].concat(
     ...(await Promise.all(
-      getSearchQueries(`repo:${owner}/${repo}+type:pr`, commits.map(commit => commit.hash)).map(async q => {
+      getSearchQueries(`repo:${owner}/${repo}+type:pr+is:merged`, commits.map(commit => commit.hash)).map(async q => {
         const {data: {items}} = await github.search.issues({q});
         return items;
       })

--- a/lib/success.js
+++ b/lib/success.js
@@ -1,5 +1,6 @@
-const {isUndefined, uniqBy, template} = require('lodash');
+const {isUndefined, uniqBy, template, flatten} = require('lodash');
 const parseGithubUrl = require('parse-github-url');
+const pFilter = require('p-filter');
 const AggregateError = require('aggregate-error');
 const issueParser = require('issue-parser')('github');
 const debug = require('debug')('semantic-release:github');
@@ -17,14 +18,14 @@ module.exports = async (
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
   const github = getClient({githubToken, githubUrl, githubApiPathPrefix});
   const releaseInfos = releases.filter(release => Boolean(release.name));
+  const shas = commits.map(commit => commit.hash);
 
-  const prs = [].concat(
-    ...(await Promise.all(
-      getSearchQueries(`repo:${owner}/${repo}+type:pr+is:merged`, commits.map(commit => commit.hash)).map(async q => {
-        const {data: {items}} = await github.search.issues({q});
-        return items;
-      })
-    ))
+  const searchQueries = getSearchQueries(`repo:${owner}/${repo}+type:pr+is:merged`, shas).map(
+    async q => (await github.search.issues({q})).data.items
+  );
+
+  const prs = await pFilter(uniqBy(flatten(await Promise.all(searchQueries)), 'number'), async ({number}) =>
+    (await github.pullRequests.getCommits({owner, repo, number})).data.find(({sha}) => shas.includes(sha))
   );
 
   debug('found pull requests: %O', prs.map(pr => pr.number));

--- a/lib/success.js
+++ b/lib/success.js
@@ -50,10 +50,16 @@ module.exports = async (
         ? template(successComment)({branch, lastRelease, commits, nextRelease, releases, issue})
         : getSuccessComment(issue, releaseInfos, nextRelease);
       try {
-        const comment = {owner, repo, number: issue.number, body};
-        debug('create comment: %O', comment);
-        const {data: {html_url: url}} = await github.issues.createComment(comment);
-        logger.log('Added comment to issue #%d: %s', issue.number, url);
+        const {data: {state}} = await github.issues.get({owner, repo, number: issue.number});
+
+        if (state === 'closed') {
+          const comment = {owner, repo, number: issue.number, body};
+          debug('create comment: %O', comment);
+          const {data: {html_url: url}} = await github.issues.createComment(comment);
+          logger.log('Added comment to issue #%d: %s', issue.number, url);
+        } else {
+          logger.log("Skip comment on issue #%d as it's open: %s", issue.number);
+        }
       } catch (err) {
         if (err.code === 404) {
           logger.error("Failed to add a comment to the issue #%d as it doesn't exists.", issue.number);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "issue-parser": "^1.0.2",
     "lodash": "^4.17.4",
     "mime": "^2.0.3",
+    "p-filter": "^1.0.0",
     "p-retry": "^1.0.0",
     "parse-github-url": "^1.0.1",
     "url-join": "^4.0.0"

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -197,6 +197,8 @@ test.serial('Comment on PR included in the releases', async t => {
         .join('+')}`
     )
     .reply(200, {items: prs})
+    .get(`/repos/${owner}/${repo}/pulls/1/commits`)
+    .reply(200, [{sha: commits[0].hash}])
     .get(`/repos/${owner}/${repo}/issues/1`)
     .reply(200, {state: 'closed'})
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
@@ -288,6 +290,8 @@ test.serial('Verify, release and notify success', async t => {
         .join('+')}`
     )
     .reply(200, {items: prs})
+    .get(`/repos/${owner}/${repo}/pulls/1/commits`)
+    .reply(200, [{sha: commits[0].hash}])
     .get(`/repos/${owner}/${repo}/issues/1`)
     .reply(200, {state: 'closed'})
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -197,6 +197,8 @@ test.serial('Comment on PR included in the releases', async t => {
         .join('+')}`
     )
     .reply(200, {items: prs})
+    .get(`/repos/${owner}/${repo}/issues/1`)
+    .reply(200, {state: 'closed'})
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
     .reply(200, {html_url: 'https://github.com/successcomment-1'})
     .get(
@@ -286,6 +288,8 @@ test.serial('Verify, release and notify success', async t => {
         .join('+')}`
     )
     .reply(200, {items: prs})
+    .get(`/repos/${owner}/${repo}/issues/1`)
+    .reply(200, {state: 'closed'})
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
     .reply(200, {html_url: 'https://github.com/successcomment-1'})
     .get(

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -192,7 +192,7 @@ test.serial('Comment on PR included in the releases', async t => {
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}})
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
         .map(commit => commit.hash)
         .join('+')}`
     )
@@ -281,7 +281,7 @@ test.serial('Verify, release and notify success', async t => {
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl})
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
         .map(commit => commit.hash)
         .join('+')}`
     )

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -110,7 +110,7 @@ test.serial('Make multiple search queries if necessary', async t => {
     {hash: repeat('d', 40), message: 'Commit 4 message'},
     {hash: repeat('e', 40), message: 'Commit 5 message'},
     {hash: repeat('f', 40), message: 'Commit 6 message'},
-    {hash: repeat('g', 40), message: 'Commit 6 message'},
+    {hash: repeat('g', 40), message: 'Commit 7 message'},
   ];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -59,7 +59,7 @@ test.serial('Add comment to PRs associated with release commits and issues close
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
         .map(commit => commit.hash)
         .join('+')}`
     )
@@ -116,13 +116,15 @@ test.serial('Make multiple search queries if necessary', async t => {
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits[0].hash}+${commits[1].hash}+${
-        commits[2].hash
-      }+${commits[3].hash}+${commits[4].hash}`
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${
+        commits[0].hash
+      }+${commits[1].hash}+${commits[2].hash}+${commits[3].hash}+${commits[4].hash}`
     )
     .reply(200, {items: [prs[0], prs[1], prs[2], prs[3], prs[4]]})
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits[5].hash}+${commits[6].hash}`
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${
+        commits[5].hash
+      }+${commits[6].hash}`
     )
     .reply(200, {items: [prs[5], prs[1]]})
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
@@ -167,7 +169,7 @@ test.serial('Do not add comment if no PR is associated with release commits', as
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
         .map(commit => commit.hash)
         .join('+')}`
     )
@@ -200,7 +202,7 @@ test.serial('Do not add comment to PR/issues from other repo', async t => {
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
         .map(commit => commit.hash)
         .join('+')}`
     )
@@ -232,7 +234,7 @@ test.serial('Ignore missing issues/PRs', async t => {
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
         .map(commit => commit.hash)
         .join('+')}`
     )
@@ -276,7 +278,7 @@ test.serial('Add custom comment', async t => {
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
         .map(commit => commit.hash)
         .join('+')}`
     )
@@ -315,7 +317,7 @@ test.serial('Ignore errors when adding comments and closing issues', async t => 
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
         .map(commit => commit.hash)
         .join('+')}`
     )
@@ -366,7 +368,7 @@ test.serial('Close open issues when a release is successful', async t => {
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
     .get(
-      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${commits
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
         .map(commit => commit.hash)
         .join('+')}`
     )


### PR DESCRIPTION
Fix semantic-release/semantic-release#726

- add comment only to merged PRs
- add comment only to closed issues/PRs
- do not add comment for unrelated PR returned by search