### PR TITLE
fix: compare release and PR commits with tree sha

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -19,13 +19,16 @@ module.exports = async (
   const github = getClient({githubToken, githubUrl, githubApiPathPrefix});
   const releaseInfos = releases.filter(release => Boolean(release.name));
   const shas = commits.map(commit => commit.hash);
+  const treeShas = commits.map(commit => commit.tree.long);
 
   const searchQueries = getSearchQueries(`repo:${owner}/${repo}+type:pr+is:merged`, shas).map(
     async q => (await github.search.issues({q})).data.items
   );
 
   const prs = await pFilter(uniqBy(flatten(await Promise.all(searchQueries)), 'number'), async ({number}) =>
-    (await github.pullRequests.getCommits({owner, repo, number})).data.find(({sha}) => shas.includes(sha))
+    (await github.pullRequests.getCommits({owner, repo, number})).data.find(
+      ({sha, commit}) => shas.includes(sha) || treeShas.includes(commit.tree.sha)
+    )
   );
 
   debug('found pull requests: %O', prs.map(pr => pr.number));

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -185,7 +185,7 @@ test.serial('Comment on PR included in the releases', async t => {
   const failTitle = 'The automated release is failing 🚨';
   const prs = [{number: 1, pull_request: {}}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
-  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const commits = [{hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}}];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
@@ -273,7 +273,7 @@ test.serial('Verify, release and notify success', async t => {
   const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const prs = [{number: 1, pull_request: {}}];
-  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const commits = [{hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}}];
   const github = authenticate()
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}})

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -51,9 +51,9 @@ test.serial('Add comment to PRs associated with release commits and issues close
   const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}, body: 'Fixes #3'}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const commits = [
-    {hash: '123', message: 'Commit 1 message\n\n Fix #1'},
-    {hash: '456', message: 'Commit 2 message'},
-    {hash: '789', message: 'Commit 3 message Closes #4'},
+    {hash: '123', message: 'Commit 1 message\n\n Fix #1', tree: {long: 'aaa'}},
+    {hash: '456', message: 'Commit 2 message', tree: {long: 'ccc'}},
+    {hash: '789', message: 'Commit 3 message Closes #4', tree: {long: 'ccc'}},
   ];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
@@ -116,13 +116,13 @@ test.serial('Make multiple search queries if necessary', async t => {
   ];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const commits = [
-    {hash: repeat('a', 40), message: 'Commit 1 message'},
-    {hash: repeat('b', 40), message: 'Commit 2 message'},
-    {hash: repeat('c', 40), message: 'Commit 3 message'},
-    {hash: repeat('d', 40), message: 'Commit 4 message'},
-    {hash: repeat('e', 40), message: 'Commit 5 message'},
-    {hash: repeat('f', 40), message: 'Commit 6 message'},
-    {hash: repeat('g', 40), message: 'Commit 7 message'},
+    {hash: repeat('a', 40), message: 'Commit 1 message', tree: {long: 'aaa'}},
+    {hash: repeat('b', 40), message: 'Commit 2 message', tree: {long: 'bbb'}},
+    {hash: repeat('c', 40), message: 'Commit 3 message', tree: {long: 'ccc'}},
+    {hash: repeat('d', 40), message: 'Commit 4 message', tree: {long: 'ddd'}},
+    {hash: repeat('e', 40), message: 'Commit 5 message', tree: {long: 'eee'}},
+    {hash: repeat('f', 40), message: 'Commit 6 message', tree: {long: 'fff'}},
+    {hash: repeat('g', 40), message: 'Commit 7 message', tree: {long: 'ggg'}},
   ];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
@@ -193,7 +193,7 @@ test.serial('Make multiple search queries if necessary', async t => {
   t.true(github.isDone());
 });
 
-test.serial('Do not add comment for unrelated PR returned by search', async t => {
+test.serial('Do not add comment for unrelated PR returned by search (compare sha)', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
   process.env.GITHUB_TOKEN = 'github_token';
@@ -201,7 +201,10 @@ test.serial('Do not add comment for unrelated PR returned by search', async t =>
   const pluginConfig = {failTitle};
   const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
-  const commits = [{hash: '123', message: 'Commit 1 message'}, {hash: '456', message: 'Commit 2 message'}];
+  const commits = [
+    {hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}},
+    {hash: '456', message: 'Commit 2 message', tree: {long: 'bbb'}},
+  ];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
@@ -214,7 +217,49 @@ test.serial('Do not add comment for unrelated PR returned by search', async t =>
     .get(`/repos/${owner}/${repo}/pulls/1/commits`)
     .reply(200, [{sha: commits[0].hash}])
     .get(`/repos/${owner}/${repo}/pulls/2/commits`)
-    .reply(200, [{sha: 'unrelated_commit'}])
+    .reply(200, [{sha: 'unrelated_commit', commit: {tree: {sha: 'unrelated_commit'}}}])
+    .get(`/repos/${owner}/${repo}/issues/1`)
+    .reply(200, {state: 'closed'})
+    .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
+    .reply(200, {html_url: 'https://github.com/successcomment-1'})
+    .get(
+      `/search/issues?q=${escape('in:title')}+${escape(`repo:${owner}/${repo}`)}+${escape('type:issue')}+${escape(
+        'state:open'
+      )}+${escape(failTitle)}`
+    )
+    .reply(200, {items: []});
+
+  await success(pluginConfig, {options, commits, nextRelease, releases, logger: t.context.logger});
+
+  t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 1, 'https://github.com/successcomment-1'));
+  t.true(github.isDone());
+});
+
+test.serial('Do not add comment for unrelated PR returned by search (compare tree sha)', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  process.env.GITHUB_TOKEN = 'github_token';
+  const failTitle = 'The automated release is failing 🚨';
+  const pluginConfig = {failTitle};
+  const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}}];
+  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const commits = [
+    {hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}},
+    {hash: '456', message: 'Commit 2 message', tree: {long: 'bbb'}},
+  ];
+  const nextRelease = {version: '1.0.0'};
+  const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
+  const github = authenticate()
+    .get(
+      `/search/issues?q=${escape(`repo:${owner}/${repo}`)}+${escape('type:pr')}+${escape('is:merged')}+${commits
+        .map(commit => commit.hash)
+        .join('+')}`
+    )
+    .reply(200, {items: prs})
+    .get(`/repos/${owner}/${repo}/pulls/1/commits`)
+    .reply(200, [{sha: 'rebased_sha', commit: {tree: {sha: commits[0].tree.long}}}])
+    .get(`/repos/${owner}/${repo}/pulls/2/commits`)
+    .reply(200, [{sha: 'unrelated_commit', commit: {tree: {sha: 'unrelated_commit'}}}])
     .get(`/repos/${owner}/${repo}/issues/1`)
     .reply(200, {state: 'closed'})
     .post(`/repos/${owner}/${repo}/issues/1/comments`, {body: /This PR is included/})
@@ -240,7 +285,7 @@ test.serial('Do not add comment to open issues/PRs', async t => {
   const pluginConfig = {failTitle};
   const prs = [{number: 1, pull_request: {}, body: 'Fixes #2'}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
-  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const commits = [{hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}}];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
@@ -279,7 +324,7 @@ test.serial('Do not add comment if no PR is associated with release commits', as
   const failTitle = 'The automated release is failing 🚨';
   const pluginConfig = {failTitle};
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
-  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const commits = [{hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}}];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
@@ -309,9 +354,9 @@ test.serial('Do not add comment to PR/issues from other repo', async t => {
   const pluginConfig = {failTitle};
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const commits = [
-    {hash: '123', message: 'Commit 1 message\n\n Fix other/other#1'},
-    {hash: '456', message: `Commit 2 message Fix ${owner}/${repo}#2`},
-    {hash: '789', message: 'Commit 3 message Closes other/other#3'},
+    {hash: '123', message: 'Commit 1 message\n\n Fix other/other#1', tree: {long: 'aaa'}},
+    {hash: '456', message: `Commit 2 message Fix ${owner}/${repo}#2`, tree: {long: 'bbb'}},
+    {hash: '789', message: 'Commit 3 message Closes other/other#3', tree: {long: 'ccc'}},
   ];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
@@ -346,7 +391,10 @@ test.serial('Ignore missing issues/PRs', async t => {
   const pluginConfig = {failTitle};
   const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}, body: 'Fixes #3'}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
-  const commits = [{hash: '123', message: 'Commit 1 message\n\n Fix #1'}, {hash: '456', message: 'Commit 2 message'}];
+  const commits = [
+    {hash: '123', message: 'Commit 1 message\n\n Fix #1', tree: {long: 'aaa'}},
+    {hash: '456', message: 'Commit 2 message', tree: {long: 'bbb'}},
+  ];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
@@ -400,7 +448,7 @@ test.serial('Add custom comment', async t => {
   const prs = [{number: 1, prop: 'PR prop', pull_request: {}}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const lastRelease = {version: '1.0.0'};
-  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const commits = [{hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}}];
   const nextRelease = {version: '2.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
@@ -443,7 +491,10 @@ test.serial('Ignore errors when adding comments and closing issues', async t => 
   ];
   const prs = [{number: 1, pull_request: {}}, {number: 2, pull_request: {}}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
-  const commits = [{hash: '123', message: 'Commit 1 message'}, {hash: '456', message: 'Commit 2 message'}];
+  const commits = [
+    {hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}},
+    {hash: '456', message: 'Commit 2 message', tree: {long: 'bbb'}},
+  ];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()
@@ -502,7 +553,7 @@ test.serial('Close open issues when a release is successful', async t => {
     {number: 3, body: `Issue 3 body\n\n${ISSUE_ID}`, title: failTitle},
   ];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
-  const commits = [{hash: '123', message: 'Commit 1 message'}];
+  const commits = [{hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}}];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate()


### PR DESCRIPTION
On GitHub, when PRs are merged via "Rebase and merged" the commit sha change, therefore comparing the shas of the release commits with the shas of the PRs found fails.

This PR use the tree sha, which stays unchanged on "Rebase and merge", as a backup to verify the PRs found contains on of the release commit.