### PR TITLE
fix typo in failure comment

### DIFF
--- a/lib/get-fail-comment.js
+++ b/lib/get-fail-comment.js
@@ -24,7 +24,7 @@ You can find below the list of errors reported by **semantic-release**. Each one
 
 Errors are usually caused by a misconfiguration or an authentication problem. With each error reported below you will find explanation and guidance to help you to resolve it.
 
-Once all the errors are resolved, **semantic-release** will release your package the next time you push a commit the \`${branch}\` branch. You can also manually restart the failed CI job that runs **semantic-release**.
+Once all the errors are resolved, **semantic-release** will release your package the next time you push a commit to the \`${branch}\` branch. You can also manually restart the failed CI job that runs **semantic-release**.
 
 If you are not sure how to resolve this, here is some links that can help you:
 - [Usage documentation](${USAGE_DOC_URL})


### PR DESCRIPTION
Just got a comment at https://github.com/electron/i18n/issues/321 which is awesome! So helpful.

Noticed a typo though. This PR should fix it.

cc @pvdlg 

