### PR TITLE
feat: parse issue referenced with full URL

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -2,7 +2,7 @@ const {isUndefined, uniqBy, template, flatten} = require('lodash');
 const parseGithubUrl = require('parse-github-url');
 const pFilter = require('p-filter');
 const AggregateError = require('aggregate-error');
-const issueParser = require('issue-parser')('github');
+const issueParser = require('issue-parser');
 const debug = require('debug')('semantic-release:github');
 const resolveConfig = require('./resolve-config');
 const getClient = require('./get-client');
@@ -17,6 +17,7 @@ module.exports = async (
   const {githubToken, githubUrl, githubApiPathPrefix, proxy, successComment, failTitle} = resolveConfig(pluginConfig);
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
   const github = getClient({githubToken, githubUrl, githubApiPathPrefix, proxy});
+  const parser = issueParser('github', githubUrl ? {hosts: [githubUrl]} : {});
   const releaseInfos = releases.filter(release => Boolean(release.name));
   const shas = commits.map(commit => commit.hash);
   const treeShas = commits.map(commit => commit.tree.long);
@@ -37,7 +38,7 @@ module.exports = async (
   const issues = [...prs.map(pr => pr.body), ...commits.map(commit => commit.message)].reduce((issues, message) => {
     return message
       ? issues.concat(
-          issueParser(message)
+          parser(message)
             .actions.filter(action => isUndefined(action.slug) || action.slug === `${owner}/${repo}`)
             .map(action => ({number: parseInt(action.issue, 10)}))
         )

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "globby": "^8.0.0",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
-    "issue-parser": "^2.0.0",
+    "issue-parser": "^2.2.0",
     "lodash": "^4.17.4",
     "mime": "^2.0.3",
     "p-filter": "^1.0.0",


### PR DESCRIPTION
Allow to parse issue referenced with both `Fix #1` and `Fix https://github.com/owner/repo/issues/1`.
Works also for PRs (`Fix https://github.com/owner/repo/pull/1`) and with custom GitHub URL (`Fix https://my-ghe.com/owner/repo/issues/1`).