### PR TITLE
fix: compare release and PR commits with merge_commit_sha

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -27,17 +27,17 @@ module.exports = async (pluginConfig, context) => {
   const github = getClient({githubToken, githubUrl, githubApiPathPrefix, proxy});
   const parser = issueParser('github', githubUrl ? {hosts: [githubUrl]} : {});
   const releaseInfos = releases.filter(release => Boolean(release.name));
-  const shas = commits.map(commit => commit.hash);
-  const treeShas = commits.map(commit => commit.tree.long);
+  const shas = commits.map(({hash}) => hash);
 
   const searchQueries = getSearchQueries(`repo:${owner}/${repo}+type:pr+is:merged`, shas).map(
     async q => (await github.search.issues({q})).data.items
   );
 
-  const prs = await pFilter(uniqBy(flatten(await Promise.all(searchQueries)), 'number'), async ({number}) =>
-    (await github.pullRequests.getCommits({owner, repo, number})).data.find(
-      ({sha, commit}) => shas.includes(sha) || treeShas.includes(commit.tree.sha)
-    )
+  const prs = await pFilter(
+    uniqBy(flatten(await Promise.all(searchQueries)), 'number'),
+    async ({number}) =>
+      (await github.pullRequests.getCommits({owner, repo, number})).data.find(({sha}) => shas.includes(sha)) ||
+      shas.includes((await github.pullRequests.get({owner, repo, number})).data.merge_commit_sha)
   );
 
   debug('found pull requests: %O', prs.map(pr => pr.number));

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -185,7 +185,7 @@ test.serial('Comment on PR included in the releases', async t => {
   const failTitle = 'The automated release is failing 🚨';
   const prs = [{number: 1, pull_request: {}, state: 'closed'}];
   const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
-  const commits = [{hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}}];
+  const commits = [{hash: '123', message: 'Commit 1 message'}];
   const nextRelease = {version: '1.0.0'};
   const releases = [{name: 'GitHub release', url: 'https://github.com/release'}];
   const github = authenticate(env)
@@ -268,7 +268,7 @@ test.serial('Verify, release and notify success', async t => {
   const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const prs = [{number: 1, pull_request: {}, state: 'closed'}];
-  const commits = [{hash: '123', message: 'Commit 1 message', tree: {long: 'aaa'}}];
+  const commits = [{hash: '123', message: 'Commit 1 message'}];
   const github = authenticate(env)
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}})


### PR DESCRIPTION
Contrary to the assumption made in #60 there is certain cases where "Rebase and merged" creates commits with a different tree sha.
That happens when the feature branch is behind the base branch, but if there is no conflicts, GitHub allows to merge with "Rebase and Merge".
In the case of "Squash and Merge" the squashed commit also has a different tree sha than the commits on the feature branch.

The algorithm now works as follow:
 - semantic-release knows only about the commits on `master` included in the release. Those commits are the result of "Create a Merge commit", "Squash and Merge" or "Rebase and Merge"
- the plugin do a GitHub search issue to find the PRs associated with the commits part of the release
- GitHub returns the associated PR, but also sometimes some unrelated ones (see #59 and semantic-release/semantic-release#726)
- The plugin calls the GitHub API for each PRs return by the search to get the commits included in the PR and make sure the PR indeed includes one of the release commit (from master) by comparing the commit shas
- The commits that were merged with "Squash and Merge" or "Rebase and Merge" will fail this test as they got a new sha when merged. So the plugin calls the GitHub API to get the PR details and compare the `merge_commit_sha` field with the the release commit shas. 

This works because when merging with "Squash and Merge" or "Rebase and Merge" GitHub will set the `merge_commit_sha` field of the merged PR to the value of the last commit sha created on master.

For example if a PR contains 2 commits with shas `sha1` and `sha2`. When merging the PR with "Rebase and Merge" the 2 commits will be merged on `master` and get new shas: `sha1-new` and `sha2-new`.
When running, semantic-release will find 2 commits to include in the release: `sha1-new` and `sha2-new`. Passing those 2 commits to the issue search API, it will return the PR. Calling the API to get the commits will returns `sha1` and `sha2`, so when the plugin test if the commits PR are in the release, the test would fail. But calling the API to get the PR details would return `merge_commit_sha` with value `sha2-new` and the plugin can verify the commit `sha2-new` on master actually comes from the PR.