### PR TITLE
fix: use `status` rather than `code` in @octokit/rest.js HttpError

### DIFF
--- a/lib/get-client.js
+++ b/lib/get-client.js
@@ -11,7 +11,7 @@ const GH_ROUTES = require('@octokit/rest/plugins/rest-api-endpoints/routes');
 const {RETRY_CONF, RATE_LIMITS, GLOBAL_RATE_LIMIT} = require('./definitions/rate-limit');
 
 /**
- * Http error codes for which to not retry.
+ * Http error status for which to not retry.
  */
 const SKIP_RETRY_CODES = [400, 401, 403];
 
@@ -98,7 +98,7 @@ const handler = (globalThrottler, limitKey) => ({
       try {
         return await throttler.wrap(func)(...args);
       } catch (error) {
-        if (SKIP_RETRY_CODES.includes(error.code)) {
+        if (SKIP_RETRY_CODES.includes(error.status)) {
           throw new pRetry.AbortError(error);
         }
         throw error;

--- a/lib/success.js
+++ b/lib/success.js
@@ -94,7 +94,7 @@ module.exports = async (pluginConfig, context) => {
             logger.log("Skip comment and labels on issue #%d as it's open: %s", issue.number);
           }
         } catch (error) {
-          if (error.code === 404) {
+          if (error.status === 404) {
             logger.error("Failed to add a comment to the issue #%d as it doesn't exists.", issue.number);
           } else {
             errors.push(error);

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -62,9 +62,9 @@ module.exports = async (pluginConfig, context) => {
         errors.push(getError('EGHNOPERMISSION', {owner, repo}));
       }
     } catch (error) {
-      if (error.code === 401) {
+      if (error.status === 401) {
         errors.push(getError('EINVALIDGHTOKEN', {owner, repo}));
-      } else if (error.code === 404) {
+      } else if (error.status === 404) {
         errors.push(getError('EMISSINGREPO', {owner, repo}));
       } else {
         throw error;

--- a/test/find-sr-issue.test.js
+++ b/test/find-sr-issue.test.js
@@ -107,7 +107,7 @@ test.serial('Retries 4 times', async t => {
 
   const error = await t.throws(findSRIssues(client, title, owner, repo));
 
-  t.is(error.code, 422);
+  t.is(error.status, 422);
   t.true(github.isDone());
 });
 
@@ -125,6 +125,6 @@ test.serial('Do not retry on 401 error', async t => {
 
   const error = await t.throws(findSRIssues(client, title, owner, repo));
 
-  t.is(error.code, 401);
+  t.is(error.status, 401);
   t.true(github.isDone());
 });

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -229,6 +229,6 @@ test.serial('Throw error without retries for 400 error', async t => {
 
   const error = await t.throws(publish(pluginConfig, {cwd, env, options, nextRelease, logger: t.context.logger}));
 
-  t.is(error.code, 400);
+  t.is(error.status, 400);
   t.true(github.isDone());
 });

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -678,8 +678,8 @@ test.serial('Ignore errors when adding comments and closing issues', async t => 
     success(pluginConfig, {env, options, commits, nextRelease, releases, logger: t.context.logger})
   );
 
-  t.is(error1.code, 400);
-  t.is(error2.code, 500);
+  t.is(error1.status, 400);
+  t.is(error2.status, 500);
   t.true(t.context.error.calledWith('Failed to add a comment to the issue #%d.', 1));
   t.true(t.context.error.calledWith('Failed to close the issue #%d.', 2));
   t.true(t.context.log.calledWith('Added comment to issue #%d: %s', 2, 'https://github.com/successcomment-2'));

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -408,7 +408,7 @@ test.serial('Throw error if github return any other errors', async t => {
     verify({}, {env, options: {repositoryUrl: `https://github.com/${owner}/${repo}.git`}, logger: t.context.logger})
   );
 
-  t.is(error.code, 500);
+  t.is(error.status, 500);
   t.true(github.isDone());
 });
 


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/pvdlg'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/pvdlg/tally.svg'></a>

`code` is deprecated in favor of `status`. 