### PR TITLE
fix: use `octokit.hook.wrap` rather than Proxies

### DIFF
--- a/lib/get-client.js
+++ b/lib/get-client.js
@@ -7,7 +7,6 @@ const urljoin = require('url-join');
 const HttpProxyAgent = require('http-proxy-agent');
 const HttpsProxyAgent = require('https-proxy-agent');
 
-const GH_ROUTES = require('@octokit/rest/plugins/rest-api-endpoints/routes');
 const {RETRY_CONF, RATE_LIMITS, GLOBAL_RATE_LIMIT} = require('./definitions/rate-limit');
 
 /**
@@ -28,90 +27,9 @@ const getThrottler = memoize((rate, globalThrottler) =>
   new Bottleneck({minTime: get(RATE_LIMITS, rate)}).chain(globalThrottler)
 );
 
-/**
- * Determine if a call to a client function will trigger a read (`GET`) or a write (`POST`, `PATCH`, etc...) request.
- *
- * @param {String} limitKey The key to find the limit rate for the  API endpoint and method.
- * @param {String} endpoint The client API enpoint (for example the endpoint for a call to `github.repos.get` is `repos`).
- * @param {String} command The client API command (for example the command for a call to `github.repos.get` is `get`).
- *
- * @return {String} `write` or `read` if there is rate limit configuration for this `endpoint` and `command`, `undefined` otherwise.
- */
-const getAccess = (limitKey, endpoint, command) => {
-  const method = GH_ROUTES[endpoint] && GH_ROUTES[endpoint][command] && GH_ROUTES[endpoint][command].method;
-  const access = method && method === 'GET' ? 'read' : 'write';
-  return RATE_LIMITS[limitKey][access] && access;
-};
-
-/**
- * Get the limiter identifier associated with a client API call.
- *
- * @param {String} limitKey The key to find the limit rate for the  API endpoint and method.
- * @param {String} endpoint The client API enpoint (for example the endpoint for a call to `github.repos.get` is `repos`).
- * @param {String} command The client API command (for example the command for a call to `github.repos.get` is `get`).
- *
- * @return {String} A string identifying the limiter to use for this `endpoint` and `command` (e.g. `search` or `core.write`).
- */
-const getLimitKey = (limitKey, endpoint, command) => {
-  return limitKey
-    ? [limitKey, RATE_LIMITS[limitKey] && getAccess(limitKey, endpoint, command)].filter(Boolean).join('.')
-    : RATE_LIMITS[command]
-    ? command
-    : 'core';
-};
-
-/**
- * Create a`handler` for a `Proxy` wrapping an Octokit instance to:
- * - Recursively wrap the child objects of the Octokit instance in a `Proxy`
- * - Throttle and retry the Octokit instance functions
- *
- * @param {Throttler} globalThrottler The throller function for the global rate limit.
- * @param {String} limitKey The key to find the limit rate for the  API endpoint and method.
- * @param {String} endpoint The client API enpoint (for example the endpoint for a call to `github.repos.get` is `repos`).
- *
- * @return {Function} The `handler` for a `Proxy` wrapping an Octokit instance.
- */
-const handler = (globalThrottler, limitKey, endpoint) => ({
-  /**
-   * If the target has the property as own, determine the rate limit based on the property name and recursively wrap the value in a `Proxy`. Otherwise returns the property value.
-   *
-   * @param {Object} target The target object.
-   * @param {String} name The name of the property to get.
-   * @param {Any} receiver The `Proxy` object.
-   *
-   * @return {Any} The property value or a `Proxy` of the property value.
-   */
-  get: (target, name, receiver) =>
-    Reflect.apply(Object.prototype.hasOwnProperty, target, [name])
-      ? new Proxy(target[name], handler(globalThrottler, getLimitKey(limitKey, endpoint, name), endpoint || name))
-      : Reflect.get(target, name, receiver),
-
-  /**
-   * Create a throttled version of the called function then call it and retry it if the call fails with certain error code.
-   *
-   * @param {Function} func The target function.
-   * @param {Any} that The this argument for the call.
-   * @param {Array} args The list of arguments for the call.
-   *
-   * @return {Promise<Any>} The result of the function called.
-   */
-  apply: (func, that, args) => {
-    const throttler = getThrottler(limitKey, globalThrottler);
-    return pRetry(async () => {
-      try {
-        return await throttler.wrap(func)(...args);
-      } catch (error) {
-        if (SKIP_RETRY_CODES.includes(error.status)) {
-          throw new pRetry.AbortError(error);
-        }
-        throw error;
-      }
-    }, RETRY_CONF);
-  },
-});
-
-module.exports = ({githubToken, githubUrl, githubApiPathPrefix, proxy} = {}) => {
+module.exports = ({githubToken, githubUrl, githubApiPathPrefix, proxy}) => {
   const baseUrl = githubUrl && urljoin(githubUrl, githubApiPathPrefix);
+  const globalThrottler = new Bottleneck({minTime: GLOBAL_RATE_LIMIT});
   const github = new Octokit({
     baseUrl,
     agent: proxy
@@ -120,6 +38,25 @@ module.exports = ({githubToken, githubUrl, githubApiPathPrefix, proxy} = {}) => 
         : new HttpsProxyAgent(proxy)
       : undefined,
   });
+
+  github.hook.wrap('request', (request, options) => {
+    const access = options.method === 'GET' ? 'read' : 'write';
+    const rateCategory = options.url.startsWith('/search') ? 'search' : 'core';
+    const limitKey = [rateCategory, RATE_LIMITS[rateCategory][access] && access].filter(Boolean).join('.');
+
+    return pRetry(async () => {
+      try {
+        return await getThrottler(limitKey, globalThrottler).wrap(request)(options);
+      } catch (error) {
+        if (SKIP_RETRY_CODES.includes(error.status)) {
+          throw new pRetry.AbortError(error);
+        }
+        throw error;
+      }
+    }, RETRY_CONF);
+  });
+
   github.authenticate({type: 'token', token: githubToken});
-  return new Proxy(github, handler(new Bottleneck({minTime: GLOBAL_RATE_LIMIT})));
+
+  return github;
 };


### PR DESCRIPTION
/cc @gr2m 

So I'm not super satisfied with the mocking strategy that relies on on `nock`.
The problem is that we add the processing time on `nock` which affect the time measured between 2 calls. So that could make the test less reliable on a very slow machine (the measurement buffer is 50 ms though).

@gr2m do you know if there is a way to stub the `request` function passed to the callback of `github.hook.wrap`? That would allow to completely bypass the http requests in the `get-client` tests so we wouldn't need `nock` in there.