### PR TITLE
fix: retrieve the branch name from `context.branch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The message for the issue comments is generated with [Lodash template](https://l
 
 | Parameter     | Description                                                                                                                                                                                                                                                                   |
 |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `branch`      | The branch from which the release is done.                                                                                                                                                                                                                                    |
+| `branch`      | `Object` with `name`, `type`, `channel`, `range` and `prerelease` properties of the branch from which the release is done.                                                                                                                                                    |
 | `lastRelease` | `Object` with `version`, `channel`, `gitTag` and `gitHead` of the last release.                                                                                                                                                                                               |
 | `nextRelease` | `Object` with `version`, `channel`, `gitTag`, `gitHead` and `notes` of the release being done.                                                                                                                                                                                |
 | `commits`     | `Array` of commit `Object`s with `hash`, `subject`, `body` `message` and `author`.                                                                                                                                                                                            |
@@ -159,12 +159,12 @@ The message for the issue content is generated with [Lodash template](https://lo
 
 | Parameter | Description                                                                                                                                                                                                                                                                                                             |
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `branch`  | The branch from which the release had failed.                                                                                                                                                                                                                                                                           |
+| `branch`  | `Object` with `name`, `type`, `channel`, `range` and `prerelease` properties of the branch from which the release is done.                                                                                                                                                                                              |
 | `errors`  | An `Array` of [SemanticReleaseError](https://github.com/semantic-release/error). Each error has the `message`, `code`, `pluginName` and `details` properties.<br>`pluginName` contains the package name of the plugin that threw the error.<br>`details` contains a informations about the error formatted in markdown. |
 
 ##### failComment example
 
-The `failComment` `This release from branch ${branch} had failed due to the following errors:\n- ${errors.map(err => err.message).join('\\n- ')}` will generate the comment:
+The `failComment` `This release from branch ${branch.name} had failed due to the following errors:\n- ${errors.map(err => err.message).join('\\n- ')}` will generate the comment:
 
 > This release from branch master had failed due to the following errors:
 > - Error message 1
@@ -176,7 +176,7 @@ Each label name is generated with [Lodash template](https://lodash.com/docs#temp
 
 | Parameter     | Description                                                                                                                                                                                                                                                                   |
 |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `branch`      | The branch from which the release is done.                                                                                                                                                                                                                                    |
+| `branch`      | `Object` with `name`, `type`, `channel`, `range` and `prerelease` properties of the branch from which the release is done.                                                                                                                                                    |
 | `lastRelease` | `Object` with `version`, `channel`, `gitTag` and `gitHead` of the last release.                                                                                                                                                                                               |
 | `nextRelease` | `Object` with `version`, `channel`, `gitTag`, `gitHead` and `notes` of the release being done.                                                                                                                                                                                |
 | `commits`     | `Array` of commit `Object`s with `hash`, `subject`, `body` `message` and `author`.                                                                                                                                                                                            |

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -9,7 +9,8 @@ const getFailComment = require('./get-fail-comment');
 
 module.exports = async (pluginConfig, context) => {
   const {
-    options: {branch, repositoryUrl},
+    options: {repositoryUrl},
+    branch,
     errors,
     logger,
   } = context;

--- a/lib/get-fail-comment.js
+++ b/lib/get-fail-comment.js
@@ -13,10 +13,9 @@ ${error.details ||
       : ''
   }`}`;
 
-module.exports = (
-  branch,
-  errors
-) => `## :rotating_light: The automated release from the \`${branch}\` branch failed. :rotating_light:
+module.exports = (branch, errors) => `## :rotating_light: The automated release from the \`${
+  branch.name
+}\` branch failed. :rotating_light:
 
 I recommend you give this issue a high priority, so other packages depending on you could benefit from your bug fixes and new features.
 
@@ -24,7 +23,9 @@ You can find below the list of errors reported by **semantic-release**. Each one
 
 Errors are usually caused by a misconfiguration or an authentication problem. With each error reported below you will find explanation and guidance to help you to resolve it.
 
-Once all the errors are resolved, **semantic-release** will release your package the next time you push a commit to the \`${branch}\` branch. You can also manually restart the failed CI job that runs **semantic-release**.
+Once all the errors are resolved, **semantic-release** will release your package the next time you push a commit to the \`${
+  branch.name
+}\` branch. You can also manually restart the failed CI job that runs **semantic-release**.
 
 If you are not sure how to resolve this, here is some links that can help you:
 - [Usage documentation](${USAGE_DOC_URL})

--- a/test/fail.test.js
+++ b/test/fail.test.js
@@ -34,7 +34,7 @@ test.serial('Open a new issue with the list of errors', async t => {
   const env = {GITHUB_TOKEN: 'github_token'};
   const failTitle = 'The automated release is failing 🚨';
   const pluginConfig = {failTitle};
-  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const options = {repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const errors = [
     new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
     new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
@@ -56,7 +56,7 @@ test.serial('Open a new issue with the list of errors', async t => {
     })
     .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
 
-  await fail(pluginConfig, {env, options, errors, logger: t.context.logger});
+  await fail(pluginConfig, {env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
@@ -68,7 +68,7 @@ test.serial('Open a new issue with the list of errors, retrying 4 times', async 
   const env = {GITHUB_TOKEN: 'github_token'};
   const failTitle = 'The automated release is failing 🚨';
   const pluginConfig = {failTitle};
-  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const options = {repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const errors = [
     new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
     new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
@@ -104,7 +104,7 @@ test.serial('Open a new issue with the list of errors, retrying 4 times', async 
     })
     .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
 
-  await fail(pluginConfig, {env, options, errors, logger: t.context.logger});
+  await fail(pluginConfig, {env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
@@ -115,9 +115,9 @@ test.serial('Open a new issue with the list of errors and custom title and comme
   const repo = 'test_repo';
   const env = {GITHUB_TOKEN: 'github_token'};
   const failTitle = 'Custom title';
-  const failComment = `branch \${branch} \${errors[0].message} \${errors[1].message} \${errors[2].message}`;
+  const failComment = `branch \${branch.name} \${errors[0].message} \${errors[1].message} \${errors[2].message}`;
   const pluginConfig = {failTitle, failComment};
-  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const options = {repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const errors = [
     new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
     new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
@@ -139,7 +139,7 @@ test.serial('Open a new issue with the list of errors and custom title and comme
     })
     .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
 
-  await fail(pluginConfig, {env, options, errors, logger: t.context.logger});
+  await fail(pluginConfig, {env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
@@ -152,7 +152,7 @@ test.serial('Open a new issue with assignees and the list of errors', async t =>
   const failTitle = 'The automated release is failing 🚨';
   const assignees = ['user1', 'user2'];
   const pluginConfig = {failTitle, assignees};
-  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const options = {repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const errors = [
     new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
     new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
@@ -174,7 +174,7 @@ test.serial('Open a new issue with assignees and the list of errors', async t =>
     })
     .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
 
-  await fail(pluginConfig, {env, options, errors, logger: t.context.logger});
+  await fail(pluginConfig, {env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
@@ -187,7 +187,7 @@ test.serial('Open a new issue without labels and the list of errors', async t =>
   const failTitle = 'The automated release is failing 🚨';
   const labels = false;
   const pluginConfig = {failTitle, labels};
-  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const options = {repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const errors = [
     new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
     new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
@@ -208,7 +208,7 @@ test.serial('Open a new issue without labels and the list of errors', async t =>
     })
     .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
 
-  await fail(pluginConfig, {env, options, errors, logger: t.context.logger});
+  await fail(pluginConfig, {env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
   t.true(github.isDone());
@@ -220,7 +220,7 @@ test.serial('Update the first existing issue with the list of errors', async t =
   const env = {GITHUB_TOKEN: 'github_token'};
   const failTitle = 'The automated release is failing 🚨';
   const pluginConfig = {failTitle};
-  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const options = {repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const errors = [
     new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
     new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
@@ -245,7 +245,7 @@ test.serial('Update the first existing issue with the list of errors', async t =
     })
     .reply(200, {html_url: 'https://github.com/issues/2', number: 2});
 
-  await fail(pluginConfig, {env, options, errors, logger: t.context.logger});
+  await fail(pluginConfig, {env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.true(t.context.log.calledWith('Found existing semantic-release issue #%d.', 2));
   t.true(t.context.log.calledWith('Added comment to issue #%d: %s.', 2, 'https://github.com/issues/2'));
@@ -257,14 +257,14 @@ test.serial('Skip if "failComment" is "false"', async t => {
   const repo = 'test_repo';
   const env = {GITHUB_TOKEN: 'github_token'};
   const pluginConfig = {failComment: false};
-  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const options = {repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const errors = [
     new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
     new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
     new SemanticReleaseError('Error message 3', 'ERR3', 'Error 3 details'),
   ];
 
-  await fail(pluginConfig, {env, options, errors, logger: t.context.logger});
+  await fail(pluginConfig, {env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.true(t.context.log.calledWith('Skip issue creation.'));
 });
@@ -274,14 +274,14 @@ test.serial('Skip if "failTitle" is "false"', async t => {
   const repo = 'test_repo';
   const env = {GITHUB_TOKEN: 'github_token'};
   const pluginConfig = {failTitle: false};
-  const options = {branch: 'master', repositoryUrl: `https://github.com/${owner}/${repo}.git`};
+  const options = {repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const errors = [
     new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details'),
     new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
     new SemanticReleaseError('Error message 3', 'ERR3', 'Error 3 details'),
   ];
 
-  await fail(pluginConfig, {env, options, errors, logger: t.context.logger});
+  await fail(pluginConfig, {env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.true(t.context.log.calledWith('Skip issue creation.'));
 });

--- a/test/get-fail-comment.test.js
+++ b/test/get-fail-comment.test.js
@@ -8,7 +8,7 @@ test('Comment with mutiple errors', t => {
     new SemanticReleaseError('Error message 2', 'ERR2', 'Error 2 details'),
     new SemanticReleaseError('Error message 3', 'ERR3', 'Error 3 details'),
   ];
-  const comment = getfailComment('master', errors);
+  const comment = getfailComment({name: 'master'}, errors);
 
   t.regex(comment, /the `master` branch/);
   t.regex(
@@ -19,7 +19,7 @@ test('Comment with mutiple errors', t => {
 
 test('Comment with one error', t => {
   const errors = [new SemanticReleaseError('Error message 1', 'ERR1', 'Error 1 details')];
-  const comment = getfailComment('master', errors);
+  const comment = getfailComment({name: 'master'}, errors);
 
   t.regex(comment, /the `master` branch/);
   t.regex(comment, /---\n\n### Error message 1\n\nError 1 details\n\n---/);
@@ -29,7 +29,7 @@ test('Comment with missing error details and pluginName', t => {
   const error = new SemanticReleaseError('Error message 1', 'ERR1');
   error.pluginName = 'some-plugin';
   const errors = [error];
-  const comment = getfailComment('master', errors);
+  const comment = getfailComment({name: 'master'}, errors);
 
   t.regex(comment, /the `master` branch/);
   t.regex(
@@ -41,7 +41,7 @@ test('Comment with missing error details and pluginName', t => {
 test('Comment with missing error details and no pluginName', t => {
   const error = new SemanticReleaseError('Error message 1', 'ERR1');
   const errors = [error];
-  const comment = getfailComment('master', errors);
+  const comment = getfailComment({name: 'master'}, errors);
 
   t.regex(comment, /the `master` branch/);
   t.regex(

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -284,7 +284,7 @@ test.serial('Open a new issue with the list of errors', async t => {
     })
     .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
 
-  await t.context.m.fail({failTitle}, {cwd, env, options, errors, logger: t.context.logger});
+  await t.context.m.fail({failTitle}, {cwd, env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
   t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));
@@ -464,7 +464,7 @@ test.serial('Verify and notify failure', async t => {
     .reply(200, {html_url: 'https://github.com/issues/1', number: 1});
 
   await t.notThrows(t.context.m.verifyConditions({}, {cwd, env, options, logger: t.context.logger}));
-  await t.context.m.fail({failTitle}, {cwd, env, options, errors, logger: t.context.logger});
+  await t.context.m.fail({failTitle}, {cwd, env, options, branch: {name: 'master'}, errors, logger: t.context.logger});
 
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
   t.true(t.context.log.calledWith('Created issue #%d: %s.', 1, 'https://github.com/issues/1'));


### PR DESCRIPTION
Fix #144