### PR TITLE
fix: also add comment/label to open issues

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -75,30 +75,24 @@ module.exports = async (pluginConfig, context) => {
           ? template(successComment)({...context, issue})
           : getSuccessComment(issue, releaseInfos, nextRelease);
         try {
-          const state = issue.state || (await github.issues.get({owner, repo, number: issue.number})).data.state;
+          const comment = {owner, repo, number: issue.number, body};
+          debug('create comment: %O', comment);
+          const {
+            data: {html_url: url},
+          } = await github.issues.createComment(comment);
+          logger.log('Added comment to issue #%d: %s', issue.number, url);
 
-          if (state === 'closed') {
-            const comment = {owner, repo, number: issue.number, body};
-            debug('create comment: %O', comment);
-            const {
-              data: {html_url: url},
-            } = await github.issues.createComment(comment);
-            logger.log('Added comment to issue #%d: %s', issue.number, url);
-
-            if (releasedLabels) {
-              const labels = releasedLabels.map(label => template(label)(context));
-              // Don’t use .issues.addLabels for GHE < 2.16 support
-              // https://github.com/semantic-release/github/issues/138
-              await github.request('POST /repos/:owner/:repo/issues/:number/labels', {
-                owner,
-                repo,
-                number: issue.number,
-                data: labels,
-              });
-              logger.log('Added labels %O to issue #%d', labels, issue.number);
-            }
-          } else {
-            logger.log("Skip comment and labels on issue #%d as it's open: %s", issue.number);
+          if (releasedLabels) {
+            const labels = releasedLabels.map(label => template(label)(context));
+            // Don’t use .issues.addLabels for GHE < 2.16 support
+            // https://github.com/semantic-release/github/issues/138
+            await github.request('POST /repos/:owner/:repo/issues/:number/labels', {
+              owner,
+              repo,
+              number: issue.number,
+              data: labels,
+            });
+            logger.log('Added labels %O to issue #%d', labels, issue.number);
           }
         } catch (error) {
           if (error.status === 404) {


### PR DESCRIPTION
It turns out [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) in PRs closes issues only when the PR get merged to the default branch.

So when merging a PR to `next` or `beta` the fixed issue is not closed so `@semantic-release/github` doesn't comment it.

This PR removes this check and we now comment on each issue fixed by a commit or its associated PR, even if GitHub didn't close the resolved issue. 