### PR TITLE
Append assets to a draft release before publishing

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -18,7 +18,18 @@ module.exports = async (pluginConfig, context) => {
   const {githubToken, githubUrl, githubApiPathPrefix, proxy, assets} = resolveConfig(pluginConfig, context);
   const {name: repo, owner} = parseGithubUrl(repositoryUrl);
   const github = getClient({githubToken, githubUrl, githubApiPathPrefix, proxy});
-  const release = {owner, repo, tag_name: gitTag, name: gitTag, target_commitish: branch, body: notes}; // eslint-disable-line camelcase
+
+  /* eslint-disable camelcase */
+  const draftRelease = {
+    owner,
+    repo,
+    tag_name: gitTag,
+    name: gitTag,
+    target_commitish: branch,
+    body: notes,
+    draft: true,
+  };
+  /* eslint-enable */
 
   debug('release owner: %o', owner);
   debug('release repo: %o', repo);
@@ -26,9 +37,8 @@ module.exports = async (pluginConfig, context) => {
   debug('release branch: %o', branch);
 
   const {
-    data: {html_url: url, upload_url: uploadUrl},
-  } = await github.repos.createRelease(release);
-  logger.log('Published GitHub release: %s', url);
+    data: {html_url: url, upload_url: uploadUrl, id: releaseId},
+  } = await github.repos.createRelease(draftRelease);
 
   if (assets && assets.length > 0) {
     const globbedAssets = await globAssets(context, assets);
@@ -76,6 +86,18 @@ module.exports = async (pluginConfig, context) => {
       })
     );
   }
+
+  /* eslint-disable camelcase */
+  const release = {
+    owner,
+    repo,
+    release_id: releaseId,
+    draft: false,
+  };
+  /* eslint-enable */
+
+  await github.repos.updateRelease(release);
+  logger.log('Published GitHub release: %s', url);
 
   return {url, name: 'GitHub release'};
 };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -152,8 +152,13 @@ test.serial('Publish a release with an array of assets', async t => {
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
     })
-    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
+    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
+      draft: false,
+    })
+    .reply(200, {html_url: releaseUrl});
   const githubUpload1 = upload(env, {
     uploadUrl: 'https://github.com',
     contentLength: (await stat(path.resolve(cwd, 'upload.txt'))).size,
@@ -171,9 +176,9 @@ test.serial('Publish a release with an array of assets', async t => {
 
   t.is(result.url, releaseUrl);
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
-  t.deepEqual(t.context.log.args[1], ['Published GitHub release: %s', releaseUrl]);
   t.true(t.context.log.calledWith('Published file %s', otherAssetUrl));
   t.true(t.context.log.calledWith('Published file %s', assetUrl));
+  t.true(t.context.log.calledWith('Published GitHub release: %s', releaseUrl));
   t.true(github.isDone());
   t.true(githubUpload1.isDone());
   t.true(githubUpload2.isDone());
@@ -285,8 +290,13 @@ test.serial('Verify, release and notify success', async t => {
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
     })
-    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl})
+    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
+      draft: false,
+    })
+    .reply(200, {html_url: releaseUrl})
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {full_name: `${owner}/${repo}`})
     .get(
@@ -328,9 +338,9 @@ test.serial('Verify, release and notify success', async t => {
   );
 
   t.deepEqual(t.context.log.args[0], ['Verify GitHub authentication']);
-  t.deepEqual(t.context.log.args[1], ['Published GitHub release: %s', releaseUrl]);
   t.true(t.context.log.calledWith('Published file %s', otherAssetUrl));
   t.true(t.context.log.calledWith('Published file %s', assetUrl));
+  t.true(t.context.log.calledWith('Published GitHub release: %s', releaseUrl));
   t.true(github.isDone());
   t.true(githubUpload1.isDone());
   t.true(githubUpload2.isDone());

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -46,8 +46,13 @@ test.serial('Publish a release', async t => {
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
     })
-    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
+    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
+      draft: false,
+    })
+    .reply(200, {html_url: releaseUrl});
 
   const result = await publish(pluginConfig, {cwd, env, options, nextRelease, logger: t.context.logger});
 
@@ -74,6 +79,7 @@ test.serial('Publish a release, retrying 4 times', async t => {
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
     })
     .times(3)
     .reply(404)
@@ -82,8 +88,13 @@ test.serial('Publish a release, retrying 4 times', async t => {
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
     })
-    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
+    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
+      draft: false,
+    })
+    .reply(200, {html_url: releaseUrl});
 
   const result = await publish(pluginConfig, {cwd, env, options, nextRelease, logger: t.context.logger});
 
@@ -113,6 +124,11 @@ test.serial('Publish a release with one asset', async t => {
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
+    })
+    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
+      draft: false,
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
 
@@ -126,7 +142,7 @@ test.serial('Publish a release with one asset', async t => {
   const result = await publish(pluginConfig, {cwd, env, options, nextRelease, logger: t.context.logger});
 
   t.is(result.url, releaseUrl);
-  t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
+  t.true(t.context.log.calledWith('Published GitHub release: %s', releaseUrl));
   t.true(t.context.log.calledWith('Published file %s', assetUrl));
   t.true(github.isDone());
   t.true(githubUpload.isDone());
@@ -153,6 +169,11 @@ test.serial('Publish a release with one asset and custom github url', async t =>
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
+    })
+    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
+      draft: false,
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
 
@@ -166,7 +187,7 @@ test.serial('Publish a release with one asset and custom github url', async t =>
   const result = await publish(pluginConfig, {cwd, env, options, nextRelease, logger: t.context.logger});
 
   t.is(result.url, releaseUrl);
-  t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
+  t.true(t.context.log.calledWith('Published GitHub release: %s', releaseUrl));
   t.true(t.context.log.calledWith('Published file %s', assetUrl));
   t.true(github.isDone());
   t.true(githubUpload.isDone());
@@ -191,13 +212,18 @@ test.serial('Publish a release with an array of missing assets', async t => {
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
     })
-    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
+    .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
+      draft: false,
+    })
+    .reply(200, {html_url: releaseUrl});
 
   const result = await publish(pluginConfig, {cwd, env, options, nextRelease, logger: t.context.logger});
 
   t.is(result.url, releaseUrl);
-  t.deepEqual(t.context.log.args[0], ['Published GitHub release: %s', releaseUrl]);
+  t.true(t.context.log.calledWith('Published GitHub release: %s', releaseUrl));
   t.true(t.context.error.calledWith('The asset %s cannot be read, and will be ignored.', 'missing.txt'));
   t.true(t.context.error.calledWith('The asset %s is not a file, and will be ignored.', emptyDirectory));
   t.true(github.isDone());
@@ -217,6 +243,7 @@ test.serial('Throw error without retries for 400 error', async t => {
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
     })
     .reply(404)
     .post(`/repos/${owner}/${repo}/releases`, {
@@ -224,6 +251,7 @@ test.serial('Throw error without retries for 400 error', async t => {
       target_commitish: options.branch,
       name: nextRelease.gitTag,
       body: nextRelease.notes,
+      draft: true,
     })
     .reply(400);
 


### PR DESCRIPTION
At Trustpilot, we have automated deployments triggered by Github releases. Our robot reacts to a release event, takes the assets from the release, and pushes them to a feed.

We started using semantic-release/github, but the release event is triggered before the assets are appended to the release, breaking our automation.

This PR changes the publish step, to create a draft release, append the assets, and then publish the release, firing the `release` event when the assets are already in it.

I'm unsure if this is a common use case, so it's understandable if you prefer not to merge.