### PR TITLE
fix: adapt for latest @octokit/rest to remove deprecation warnings

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -30,7 +30,8 @@ module.exports = async (pluginConfig, context) => {
 
     if (srIssue) {
       logger.log('Found existing semantic-release issue #%d.', srIssue.number);
-      const comment = {owner, repo, number: srIssue.number, body};
+      // eslint-disable-next-line camelcase
+      const comment = {owner, repo, issue_number: srIssue.number, body};
       debug('create comment: %O', comment);
       const {
         data: {html_url: url},

--- a/lib/success.js
+++ b/lib/success.js
@@ -51,8 +51,10 @@ module.exports = async (pluginConfig, context) => {
     const prs = await pFilter(
       uniqBy(flatten(await Promise.all(searchQueries)), 'number'),
       async ({number}) =>
-        (await github.pullRequests.listCommits({owner, repo, number})).data.find(({sha}) => shas.includes(sha)) ||
-        shas.includes((await github.pullRequests.get({owner, repo, number})).data.merge_commit_sha)
+        // eslint-disable-next-line camelcase
+        (await github.pullRequests.listCommits({owner, repo, pull_number: number})).data.find(({sha}) =>
+          shas.includes(sha)
+        ) || shas.includes((await github.pullRequests.get({owner, repo, pull_number: number})).data.merge_commit_sha) // eslint-disable-line camelcase
     );
 
     debug('found pull requests: %O', prs.map(pr => pr.number));
@@ -76,10 +78,12 @@ module.exports = async (pluginConfig, context) => {
           ? template(successComment)({branch, lastRelease, commits, nextRelease, releases, issue})
           : getSuccessComment(issue, releaseInfos, nextRelease);
         try {
-          const state = issue.state || (await github.issues.get({owner, repo, number: issue.number})).data.state;
+          // eslint-disable-next-line camelcase
+          const state = issue.state || (await github.issues.get({owner, repo, issue_number: issue.number})).data.state;
 
           if (state === 'closed') {
-            const comment = {owner, repo, number: issue.number, body};
+            // eslint-disable-next-line camelcase
+            const comment = {owner, repo, issue_number: issue.number, body};
             debug('create comment: %O', comment);
             const {
               data: {html_url: url},
@@ -124,7 +128,8 @@ module.exports = async (pluginConfig, context) => {
       srIssues.map(async issue => {
         debug('close issue: %O', issue);
         try {
-          const updateIssue = {owner, repo, number: issue.number, state: 'closed'};
+          // eslint-disable-next-line camelcase
+          const updateIssue = {owner, repo, issue_number: issue.number, state: 'closed'};
           debug('closing issue: %O', updateIssue);
           const {
             data: {html_url: url},


### PR DESCRIPTION
- The goal of this PR to correct the deprecated param from octokit/rest.
- Calling with deprecated param will get this warning
```
{ Deprecation: [@octokit/rest] "number" parameter is deprecated for ".pullRequests.listCommits()". Use "pull_number" instead
    at Object.keys.forEach.key (/Users/sbtrung/.nvm/versions/node/v10.12.0/lib/node_modules/semantic-release/node_modules/@octokit/rest/plugins/register-endpoints/register-endpoints.js:73:26)
    at Array.forEach (<anonymous>)
    at Object.patchedMethod [as listCommits] (/Users/sbtrung/.nvm/versions/node/v10.12.0/lib/node_modules/semantic-release/node_modules/@octokit/rest/plugins/register-endpoints/register-endpoints.js:69:26)
    at pFilter (/Users/sbtrung/.nvm/versions/node/v10.12.0/lib/node_modules/semantic-release/node_modules/@semantic-release/github/lib/success.js:54:36)
    at pMap (/Users/sbtrung/.nvm/versions/node/v10.12.0/lib/node_modules/semantic-release/node_modules/p-filter/index.js:5:46)
    at Promise.resolve.then.el (/Users/sbtrung/.nvm/versions/node/v10.12.0/lib/node_modules/semantic-release/node_modules/p-map/index.js:46:16) name: 'Deprecation' }
{ Deprecation: [@octokit/rest] "number" parameter is deprecated for ".issues.createComment()". Use "issue_number" instead
    at Object.keys.forEach.key (/Users/sbtrung/.nvm/versions/node/v10.12.0/lib/node_modules/semantic-release/node_modules/@octokit/rest/plugins/register-endpoints/register-endpoints.js:73:26)
    at Array.forEach (<anonymous>)
    at Object.patchedMethod [as createComment] (/Users/sbtrung/.nvm/versions/node/v10.12.0/lib/node_modules/semantic-release/node_modules/@octokit/rest/plugins/register-endpoints/register-endpoints.js:69:26)
    at Promise.all.uniqBy.map (/Users/sbtrung/.nvm/versions/node/v10.12.0/lib/node_modules/semantic-release/node_modules/@semantic-release/github/lib/success.js:86:37)
    at Array.map (<anonymous>)
    at module.exports (/Users/sbtrung/.nvm/versions/node/v10.12.0/lib/node_modules/semantic-release/node_modules/@semantic-release/github/lib/success.js:74:45) name: 'Deprecation' }

```

- The original code from octokit/rest is : https://github.com/octokit/rest.js/blob/master/plugins/register-endpoints/register-endpoints.js#L73