### PR TITLE
fix: use the `branch.main` flag to determine is the release need the `prerelease` flag

### DIFF
--- a/lib/add-channel.js
+++ b/lib/add-channel.js
@@ -9,7 +9,6 @@ module.exports = async (pluginConfig, context) => {
   const {
     options: {repositoryUrl},
     branch,
-    currentRelease: {gitTag: currentGitTag, channel: currentChannel},
     nextRelease: {name, gitTag, notes},
     logger,
   } = context;
@@ -18,27 +17,21 @@ module.exports = async (pluginConfig, context) => {
   const github = getClient({githubToken, githubUrl, githubApiPathPrefix, proxy});
   let releaseId;
 
-  const release = {owner, repo, name, prerelease: isPrerelease(branch)};
+  const release = {owner, repo, name, prerelease: isPrerelease(branch), tag_name: gitTag};
 
-  debug('release owner: %o', release.owner);
-  debug('release repo: %o', release.repo);
-  debug('release tag_name: %o', release.tag_name);
-  debug('release name: %o', release.name);
-  debug('release prerelease: %o', release.prerelease);
+  debug('release object: %O', release);
 
   try {
     ({
       data: {id: releaseId},
-    } = await github.repos.getReleaseByTag({owner, repo, tag: currentGitTag}));
+    } = await github.repos.getReleaseByTag({owner, repo, tag: gitTag}));
   } catch (error) {
     if (error.status === 404) {
-      logger.log('There is no release for tag %s, creating a new one', currentGitTag);
-
-      debug('release tag_name: %o', gitTag);
+      logger.log('There is no release for tag %s, creating a new one', gitTag);
 
       const {
         data: {html_url: url},
-      } = await github.repos.createRelease({...release, body: notes, tag_name: gitTag});
+      } = await github.repos.createRelease({...release, body: notes});
 
       logger.log('Published GitHub release: %s', url);
       return {url, name: RELEASE_NAME};
@@ -47,14 +40,11 @@ module.exports = async (pluginConfig, context) => {
     throw error;
   }
 
-  const tagName = currentChannel ? gitTag : undefined;
-
   debug('release release_id: %o', releaseId);
-  debug('release tag_name: %o', tagName);
 
   const {
     data: {html_url: url},
-  } = await github.repos.updateRelease({...release, release_id: releaseId, tag_name: tagName});
+  } = await github.repos.updateRelease({...release, release_id: releaseId});
 
   logger.log('Updated GitHub release: %s', url);
 

--- a/lib/is-prerelease.js
+++ b/lib/is-prerelease.js
@@ -1,1 +1,1 @@
-module.exports = ({type, channel}) => type === 'prerelease' || (type === 'release' && Boolean(channel));
+module.exports = ({type, main}) => type === 'prerelease' || (type === 'release' && !main);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -170,7 +170,7 @@ test.serial('Publish a release with an array of assets', async t => {
 
   const result = await t.context.m.publish(
     {assets},
-    {cwd, env, options, branch: {type: 'release'}, nextRelease, logger: t.context.logger}
+    {cwd, env, options, branch: {type: 'release', main: true}, nextRelease, logger: t.context.logger}
   );
 
   t.is(result.url, releaseUrl);
@@ -244,7 +244,6 @@ test.serial('Update a release', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
   const env = {GITHUB_TOKEN: 'github_token'};
-  const currentRelease = {gitTag: 'v1.0.0@next', channel: 'next', name: 'v1.0.0', notes: 'Test release note body'};
   const nextRelease = {gitTag: 'v1.0.0', name: 'v1.0.0', notes: 'Test release note body'};
   const options = {repositoryUrl: `https://github.com/${owner}/${repo}.git`};
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
@@ -253,7 +252,7 @@ test.serial('Update a release', async t => {
   const github = authenticate(env)
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}})
-    .get(`/repos/${owner}/${repo}/releases/tags/${currentRelease.gitTag}`)
+    .get(`/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`)
     .reply(200, {id: releaseId})
     .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
       tag_name: nextRelease.gitTag,
@@ -264,7 +263,7 @@ test.serial('Update a release', async t => {
 
   const result = await t.context.m.addChannel(
     {},
-    {cwd, env, options, branch: {type: 'release'}, currentRelease, nextRelease, logger: t.context.logger}
+    {cwd, env, options, branch: {type: 'release', main: true}, nextRelease, logger: t.context.logger}
   );
 
   t.is(result.url, releaseUrl);
@@ -419,7 +418,7 @@ test.serial('Verify, release and notify success', async t => {
   await t.notThrowsAsync(t.context.m.verifyConditions({}, {cwd, env, options, logger: t.context.logger}));
   await t.context.m.publish(
     {assets},
-    {cwd, env, options, branch: {type: 'release'}, nextRelease, logger: t.context.logger}
+    {cwd, env, options, branch: {type: 'release', main: true}, nextRelease, logger: t.context.logger}
   );
   await t.context.m.success(
     {assets, failTitle},
@@ -444,7 +443,6 @@ test.serial('Verify, update release and notify success', async t => {
     publish: [{path: '@semantic-release/npm'}, {path: '@semantic-release/github'}],
     repositoryUrl: `https://github.com/${owner}/${repo}.git`,
   };
-  const currentRelease = {gitTag: 'v1.0.0@next', channel: 'next', name: 'v1.0.0', notes: 'Test release note body'};
   const nextRelease = {gitTag: 'v1.0.0', name: 'v1.0.0', notes: 'Test release note body'};
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
   const releaseId = 1;
@@ -453,7 +451,7 @@ test.serial('Verify, update release and notify success', async t => {
   const github = authenticate(env)
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {permissions: {push: true}})
-    .get(`/repos/${owner}/${repo}/releases/tags/${currentRelease.gitTag}`)
+    .get(`/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`)
     .reply(200, {id: releaseId})
     .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
       tag_name: nextRelease.gitTag,
@@ -485,7 +483,7 @@ test.serial('Verify, update release and notify success', async t => {
   await t.notThrowsAsync(t.context.m.verifyConditions({}, {cwd, env, options, logger: t.context.logger}));
   await t.context.m.addChannel(
     {},
-    {cwd, env, branch: {type: 'release'}, currentRelease, nextRelease, options, logger: t.context.logger}
+    {cwd, env, branch: {type: 'release', main: true}, nextRelease, options, logger: t.context.logger}
   );
   await t.context.m.success(
     {failTitle},

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -53,7 +53,7 @@ test.serial('Publish a release', async t => {
     cwd,
     env,
     options,
-    branch: {type: 'release'},
+    branch: {type: 'release', main: true},
     nextRelease,
     logger: t.context.logger,
   });
@@ -88,7 +88,7 @@ test.serial('Publish a release on a channel', async t => {
     cwd,
     env,
     options,
-    branch: {type: 'release', channel: 'next'},
+    branch: {type: 'release', channel: 'next', main: false},
     nextRelease,
     logger: t.context.logger,
   });
@@ -133,7 +133,7 @@ test.serial('Publish a prerelease', async t => {
   t.true(github.isDone());
 });
 
-test.serial('Publish a lts release', async t => {
+test.serial('Publish a maintenance release', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
   const env = {GITHUB_TOKEN: 'github_token'};
@@ -158,7 +158,7 @@ test.serial('Publish a lts release', async t => {
     cwd,
     env,
     options,
-    branch: {type: 'lts', channel: '1.x'},
+    branch: {type: 'maintenance', channel: '1.x', main: false},
     nextRelease,
     logger: t.context.logger,
   });
@@ -201,7 +201,7 @@ test.serial('Publish a release, retrying 4 times', async t => {
     cwd,
     env,
     options,
-    branch: {type: 'release'},
+    branch: {type: 'release', main: true},
     nextRelease,
     logger: t.context.logger,
   });
@@ -250,7 +250,7 @@ test.serial('Publish a release with one asset', async t => {
     cwd,
     env,
     options,
-    branch: {type: 'release'},
+    branch: {type: 'release', main: true},
     nextRelease,
     logger: t.context.logger,
   });
@@ -301,7 +301,7 @@ test.serial('Publish a release with one asset and custom github url', async t =>
     cwd,
     env,
     options,
-    branch: {type: 'release'},
+    branch: {type: 'release', main: true},
     nextRelease,
     logger: t.context.logger,
   });
@@ -343,7 +343,7 @@ test.serial('Publish a release with an array of missing assets', async t => {
     cwd,
     env,
     options,
-    branch: {type: 'release'},
+    branch: {type: 'release', main: true},
     nextRelease,
     logger: t.context.logger,
   });
@@ -380,7 +380,14 @@ test.serial('Throw error without retries for 400 error', async t => {
     .reply(400);
 
   const error = await t.throwsAsync(
-    publish(pluginConfig, {cwd, env, options, branch: {type: 'release'}, nextRelease, logger: t.context.logger})
+    publish(pluginConfig, {
+      cwd,
+      env,
+      options,
+      branch: {type: 'release', main: true},
+      nextRelease,
+      logger: t.context.logger,
+    })
   );
 
   t.is(error.status, 400);


### PR DESCRIPTION
That will avoid wrongly setting `prereleasae` to `true` in case of the main branch defining a custom `channel`.