### PR TITLE
fix: skip permission verification exception when Github Apps

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -69,6 +69,14 @@ module.exports = async (pluginConfig, context) => {
         },
       } = await github.repos.get({repo, owner});
       if (!push) {
+        // If authenticated as GitHub App installation, `push` will always be false.
+        // We send another request to check if current authentication is an installation.
+        // Note: we cannot check if the installation has all required permissions, it's
+        // up to the user to make sure it has
+        if (await github.request('HEAD /installation/repositories', {per_page: 1}).catch(() => false)) {
+          return;
+        }
+
         errors.push(getError('EGHNOPERMISSION', {owner, repo}));
       }
     } catch (error) {


### PR DESCRIPTION
Similar to Github Actions, when using installation tokens from Github Apps the verification should be skipped.

Should we use a more generic flag for skipping the permission validation? e.g. `SKIP_PERMISSIONS`?

I will add the relevant docs to the Readme once I get the ok.