### PR TITLE
ci: remove double builds for renovate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - renovate/**
 
   pull_request:
     types:


### PR DESCRIPTION
I was discussing with @travi to use this change as a starting point to adapt https://adr.github.io/ as we are both interested in ADR