### PR TITLE
fix: include tag_name in updateRelease

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -99,7 +99,7 @@ module.exports = async (pluginConfig, context) => {
 
   const {
     data: {html_url: url},
-  } = await github.repos.updateRelease({owner, repo, release_id: releaseId, draft: false});
+  } = await github.repos.updateRelease({owner, repo, release_id: releaseId, draft: false, tag_name: draftRelease.tag_name});
 
   logger.log('Published GitHub release: %s', url);
   return {url, name: RELEASE_NAME, id: releaseId};

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -99,7 +99,13 @@ module.exports = async (pluginConfig, context) => {
 
   const {
     data: {html_url: url},
-  } = await github.repos.updateRelease({owner, repo, release_id: releaseId, draft: false, tag_name: draftRelease.tag_name});
+  } = await github.repos.updateRelease({
+    owner,
+    repo,
+    release_id: releaseId,
+    draft: false,
+    tag_name: draftRelease.tag_name,
+  });
 
   logger.log('Published GitHub release: %s', url);
   return {url, name: RELEASE_NAME, id: releaseId};

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -153,7 +153,7 @@ test.serial('Publish a release with an array of assets', async (t) => {
       prerelease: false,
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
-    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false, tag_name: nextRelease.gitTag})
     .reply(200, {html_url: releaseUrl});
   const githubUpload1 = upload(env, {
     uploadUrl: 'https://github.com',
@@ -214,6 +214,7 @@ test.serial('Publish a release with release information in assets', async (t) =>
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
     .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {
       draft: false,
+      tag_name: nextRelease.gitTag,
     })
     .reply(200, {html_url: releaseUrl});
   const githubUpload = upload(env, {
@@ -380,7 +381,7 @@ test.serial('Verify, release and notify success', async (t) => {
       prerelease: false,
     })
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl, id: releaseId})
-    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false, tag_name: nextRelease.gitTag})
     .reply(200, {html_url: releaseUrl})
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {full_name: `${owner}/${repo}`})

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -249,7 +249,7 @@ test.serial('Publish a release with one asset', async (t) => {
       prerelease: false,
     })
     .reply(200, {upload_url: uploadUrl, html_url: untaggedReleaseUrl, id: releaseId})
-    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false, tag_name: nextRelease.gitTag})
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
 
   const githubUpload = upload(env, {
@@ -302,7 +302,7 @@ test.serial('Publish a release with one asset and custom github url', async (t) 
       prerelease: false,
     })
     .reply(200, {upload_url: uploadUrl, html_url: untaggedReleaseUrl, id: releaseId})
-    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false, tag_name: nextRelease.gitTag})
     .reply(200, {upload_url: uploadUrl, html_url: releaseUrl});
 
   const githubUpload = upload(env, {
@@ -353,7 +353,7 @@ test.serial('Publish a release with an array of missing assets', async (t) => {
       prerelease: false,
     })
     .reply(200, {upload_url: uploadUrl, html_url: untaggedReleaseUrl, id: releaseId})
-    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false})
+    .patch(`/repos/${owner}/${repo}/releases/${releaseId}`, {draft: false, tag_name: nextRelease.gitTag})
     .reply(200, {html_url: releaseUrl});
 
   const result = await publish(pluginConfig, {


### PR DESCRIPTION
###  Problem
untagged release when a release includes assets upload.

### Fix
When release with assets is needed, we update previously created draft release (in order to attach assets) by adding `tag_name` in github api call . `tag_name` option in not required based on git docs. 

Details in https://github.com/semantic-release/github/issues/362

Must read comment: https://github.com/semantic-release/github/issues/362#issuecomment-830261465


**NOTE**

DRAFT PR since my skills aren't node based (python dev).  Need time to understand/learn/explore the unit tests failures.
Help is appreciated. 