### PR TITLE
docs: fix name of GitHub Actions permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you have actions that trigger on newly created releases, please use a generat
 
 When using the _GITHUB_TOKEN_, the **minimum required permissions** are:
 
-- `content: write` to be able to publish a GitHub release
+- `contents: write` to be able to publish a GitHub release
 - `issues: write` to be able to comment on released issues
 - `pull-requests: write` to be able to comment on released pull requests
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ When using the _GITHUB_TOKEN_, the **minimum required permissions** are:
 
 - `content: write` to be able to publish a GitHub release
 - `issues: write` to be able to comment on released issues
-- `pulls: write` to be able to comment on released pull requests
+- `pull-requests: write` to be able to comment on released pull requests
 
 ### Environment variables
 


### PR DESCRIPTION
Update the documentation of the minimum required permissions of the default GitHub Actions `GITHUB_TOKEN` token needed to use this plugin. In my previous pull request I used the wrong key for the `contents` and `pull-requests` permission (apologies for that, found out about it only after trying to create a release with an invalid workflow :sweat_smile:).

You can view [the permissions documentation](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions) to verify this change. Also, [this CI run](https://github.com/birjolaxew/svglint/runs/4725048163) that's based on [this workflow file](https://github.com/birjolaxew/svglint/blob/3ab00548d0df619a9a1f751ff303065035b5dbf7/.github/workflows/release.yml) shows the documentation is now correct.

Follow-up of #459 