### PR TITLE
fix: add label(s) without success comment if successComment is false

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -37,85 +37,85 @@ module.exports = async (pluginConfig, context) => {
   const [owner, repo] = (await github.repos.get(parseGithubUrl(repositoryUrl))).data.full_name.split('/');
 
   const errors = [];
+  
+  const parser = issueParser('github', githubUrl ? {hosts: [githubUrl]} : {});
+  const releaseInfos = releases.filter((release) => Boolean(release.name));
+  const shas = commits.map(({hash}) => hash);
 
-  if (successComment === false) {
-    logger.log('Skip commenting on issues and pull requests.');
-  } else {
-    const parser = issueParser('github', githubUrl ? {hosts: [githubUrl]} : {});
-    const releaseInfos = releases.filter((release) => Boolean(release.name));
-    const shas = commits.map(({hash}) => hash);
+  const searchQueries = getSearchQueries(`repo:${owner}/${repo}+type:pr+is:merged`, shas).map(
+    async (q) => (await github.search.issuesAndPullRequests({q})).data.items
+  );
 
-    const searchQueries = getSearchQueries(`repo:${owner}/${repo}+type:pr+is:merged`, shas).map(
-      async (q) => (await github.search.issuesAndPullRequests({q})).data.items
-    );
+  const prs = await pFilter(
+    uniqBy(flatten(await Promise.all(searchQueries)), 'number'),
+    async ({number}) =>
+      (await github.pulls.listCommits({owner, repo, pull_number: number})).data.find(({sha}) => shas.includes(sha)) ||
+      shas.includes((await github.pulls.get({owner, repo, pull_number: number})).data.merge_commit_sha)
+  );
 
-    const prs = await pFilter(
-      uniqBy(flatten(await Promise.all(searchQueries)), 'number'),
-      async ({number}) =>
-        (await github.pulls.listCommits({owner, repo, pull_number: number})).data.find(({sha}) => shas.includes(sha)) ||
-        shas.includes((await github.pulls.get({owner, repo, pull_number: number})).data.merge_commit_sha)
-    );
+  debug(
+    'found pull requests: %O',
+    prs.map((pr) => pr.number)
+  );
 
-    debug(
-      'found pull requests: %O',
-      prs.map((pr) => pr.number)
-    );
+  // Parse the release commits message and PRs body to find resolved issues/PRs via comment keyworkds
+  const issues = [...prs.map((pr) => pr.body), ...commits.map((commit) => commit.message)].reduce(
+    (issues, message) => {
+      return message
+        ? issues.concat(
+            parser(message)
+              .actions.close.filter((action) => isNil(action.slug) || action.slug === `${owner}/${repo}`)
+              .map((action) => ({number: Number.parseInt(action.issue, 10)}))
+          )
+        : issues;
+    },
+    []
+  );
 
-    // Parse the release commits message and PRs body to find resolved issues/PRs via comment keyworkds
-    const issues = [...prs.map((pr) => pr.body), ...commits.map((commit) => commit.message)].reduce(
-      (issues, message) => {
-        return message
-          ? issues.concat(
-              parser(message)
-                .actions.close.filter((action) => isNil(action.slug) || action.slug === `${owner}/${repo}`)
-                .map((action) => ({number: Number.parseInt(action.issue, 10)}))
-            )
-          : issues;
-      },
-      []
-    );
+  debug('found issues via comments: %O', issues);
 
-    debug('found issues via comments: %O', issues);
-
-    await Promise.all(
-      uniqBy([...prs, ...issues], 'number').map(async (issue) => {
-        const body = successComment
-          ? template(successComment)({...context, issue})
-          : getSuccessComment(issue, releaseInfos, nextRelease);
-        try {
+  await Promise.all(
+    uniqBy([...prs, ...issues], 'number').map(async (issue) => {
+      const body = successComment
+        ? template(successComment)({...context, issue})
+        : getSuccessComment(issue, releaseInfos, nextRelease);
+      try {
+        if (successComment === false) {
+          logger.log('Skip commenting on issues and pull requests.');
+        } else {
           const comment = {owner, repo, issue_number: issue.number, body};
           debug('create comment: %O', comment);
           const {
             data: {html_url: url},
           } = await github.issues.createComment(comment);
           logger.log('Added comment to issue #%d: %s', issue.number, url);
-
-          if (releasedLabels) {
-            const labels = releasedLabels.map((label) => template(label)(context));
-            // Don’t use .issues.addLabels for GHE < 2.16 support
-            // https://github.com/semantic-release/github/issues/138
-            await github.request('POST /repos/:owner/:repo/issues/:number/labels', {
-              owner,
-              repo,
-              number: issue.number,
-              data: labels,
-            });
-            logger.log('Added labels %O to issue #%d', labels, issue.number);
-          }
-        } catch (error) {
-          if (error.status === 403) {
-            logger.error('Not allowed to add a comment to the issue #%d.', issue.number);
-          } else if (error.status === 404) {
-            logger.error("Failed to add a comment to the issue #%d as it doesn't exist.", issue.number);
-          } else {
-            errors.push(error);
-            logger.error('Failed to add a comment to the issue #%d.', issue.number);
-            // Don't throw right away and continue to update other issues
-          }
         }
-      })
-    );
-  }
+
+        if (releasedLabels) {
+          const labels = releasedLabels.map((label) => template(label)(context));
+          // Don’t use .issues.addLabels for GHE < 2.16 support
+          // https://github.com/semantic-release/github/issues/138
+          await github.request('POST /repos/:owner/:repo/issues/:number/labels', {
+            owner,
+            repo,
+            number: issue.number,
+            data: labels,
+          });
+          logger.log('Added labels %O to issue #%d', labels, issue.number);
+        }
+      } catch (error) {
+        if (error.status === 403) {
+          logger.error('Not allowed to add a comment to the issue #%d.', issue.number);
+        } else if (error.status === 404) {
+          logger.error("Failed to add a comment to the issue #%d as it doesn't exist.", issue.number);
+        } else {
+          errors.push(error);
+          logger.error('Failed to add a comment to the issue #%d.', issue.number);
+          // Don't throw right away and continue to update other issues
+        }
+      }
+    })
+  );
 
   if (failComment === false || failTitle === false) {
     logger.log('Skip closing issue.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@semantic-release/github",
-  "description": "semantic-release plugin to publish a GitHub release and comment on released Pull Requests/Issues",
+  "name": "@june21x/semantic-release-github-no-comment",
+  "description": "Fork from semantic-release plugin to label without comment",
   "version": "0.0.0-development",
   "author": "Pierre Vanduynslager (https://twitter.com/@pvdlg_)",
   "ava": {


### PR DESCRIPTION
Currently the `successComment` and `releasedLabels`  behaviour are not decoupled.
My team is currently using this and wish to label each released issue with latest release version, so that we could filter out issues based on release version on the labels when working with GitHub's Project V2 automation workflow.

However, the `successComment` on multiple issues will trigger a lot of emails and GitHub Teams App notifications, which we would like to turn off to avoid annoying notification spamming.

This PR removes the coupling between `successComment` and `releasedLabels`, so that user could feel free to add labels without the bot comments.

close #421