### PR TITLE
fix: define retry limit in retry config

### DIFF
--- a/lib/definitions/retry.js
+++ b/lib/definitions/retry.js
@@ -1,8 +1,9 @@
 /**
- * Default exponential backoff configuration for retries.
+ * Default retry config for octokit retry plugin
  */
 export const RETRY_CONF = {
   // By default, Octokit does not retry on 404s.
   // But we want to retry on 404s to account for replication lag.
   doNotRetry: [400, 401, 403, 422],
+  retries: 3,
 };


### PR DESCRIPTION
Potential fix to #644 

The current retry logic attempts to see if the retry limit has been hit but it does this by checking against an undefined value.

This may have been an oversight from #487 as `RETRY_CONFIG` did have a `retries` property, but it was removed.