### PR TITLE
feat(node-versions): dropped support for node v18 and v19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18.0.0
-          - 19
+          - 20.8.1
           - 20
+          - 21
         os:
           - ubuntu-latest
     runs-on: "${{ matrix.os }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "tempy": "3.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.8.1"
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "tempy": "3.1.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.8.1"
   },
   "files": [
     "lib",


### PR DESCRIPTION
BREAKING CHANGE: node v18 and v19 are no longer supported