### PR TITLE
Fixed homepage link in package.json so the generated links in the errors are valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lib",
     "index.js"
   ],
-  "homepage": "https://github.com/semantic-release/github#readme",
+  "homepage": "https://github.com/semantic-release/github",
   "keywords": [
     "git",
     "github",


### PR DESCRIPTION
Eg: _A GitHub personal token (https://github.com/semantic-release/github#readme/blob/master/README.md#github-authentication) must be created and set in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment._ is the currently generated error message. 
This PR will fix the link in the error being invalid.