### PR TITLE
ref: Remove usage of aggregate-error library

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -1,6 +1,5 @@
 import { isNil, uniqBy, template, flatten, isEmpty } from "lodash-es";
 import pFilter from "p-filter";
-import AggregateError from "aggregate-error";
 import issueParser from "issue-parser";
 import debugFactory from "debug";
 
@@ -42,13 +41,13 @@ export default async function success(pluginConfig, context, { Octokit }) {
       githubApiPathPrefix,
       githubApiUrl,
       proxy,
-    }),
+    })
   );
 
   // In case the repo changed name, get the new `repo`/`owner` as the search API will not follow redirects
   const { data: repoData } = await octokit.request(
     "GET /repos/{owner}/{repo}",
-    parseGithubUrl(repositoryUrl),
+    parseGithubUrl(repositoryUrl)
   );
   const [owner, repo] = repoData.full_name.split("/");
 
@@ -59,17 +58,17 @@ export default async function success(pluginConfig, context, { Octokit }) {
   } else {
     const parser = issueParser(
       "github",
-      githubUrl ? { hosts: [githubUrl] } : {},
+      githubUrl ? { hosts: [githubUrl] } : {}
     );
     const releaseInfos = releases.filter((release) => Boolean(release.name));
     const shas = commits.map(({ hash }) => hash);
 
     const { repository } = await octokit.graphql(
       buildAssociatedPRsQuery(shas),
-      { owner, repo },
+      { owner, repo }
     );
     const associatedPRs = Object.values(repository).map(
-      (item) => item.associatedPullRequests.nodes,
+      (item) => item.associatedPullRequests.nodes
     );
 
     const uniqueAssociatedPRs = uniqBy(flatten(associatedPRs), "number");
@@ -81,7 +80,7 @@ export default async function success(pluginConfig, context, { Octokit }) {
           owner,
           repo,
           pull_number: number,
-        },
+        }
       );
       const matchingCommit = commits.find(({ sha }) => shas.includes(sha));
       if (matchingCommit) return matchingCommit;
@@ -92,14 +91,14 @@ export default async function success(pluginConfig, context, { Octokit }) {
           owner,
           repo,
           pull_number: number,
-        },
+        }
       );
       return shas.includes(pullRequest.merge_commit_sha);
     });
 
     debug(
       "found pull requests: %O",
-      prs.map((pr) => pr.number),
+      prs.map((pr) => pr.number)
     );
 
     // Parse the release commits message and PRs body to find resolved issues/PRs via comment keyworkds
@@ -113,14 +112,14 @@ export default async function success(pluginConfig, context, { Octokit }) {
               parser(message)
                 .actions.close.filter(
                   (action) =>
-                    isNil(action.slug) || action.slug === `${owner}/${repo}`,
+                    isNil(action.slug) || action.slug === `${owner}/${repo}`
                 )
                 .map((action) => ({
                   number: Number.parseInt(action.issue, 10),
-                })),
+                }))
             )
           : issues,
-      [],
+      []
     );
 
     debug("found issues via comments: %O", issues);
@@ -137,13 +136,13 @@ export default async function success(pluginConfig, context, { Octokit }) {
             data: { html_url: url },
           } = await octokit.request(
             "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-            comment,
+            comment
           );
           logger.log("Added comment to issue #%d: %s", issue.number, url);
 
           if (releasedLabels) {
             const labels = releasedLabels.map((label) =>
-              template(label)(context),
+              template(label)(context)
             );
             await octokit.request(
               "POST /repos/{owner}/{repo}/issues/{issue_number}/labels",
@@ -152,7 +151,7 @@ export default async function success(pluginConfig, context, { Octokit }) {
                 repo,
                 issue_number: issue.number,
                 data: labels,
-              },
+              }
             );
             logger.log("Added labels %O to issue #%d", labels, issue.number);
           }
@@ -160,23 +159,23 @@ export default async function success(pluginConfig, context, { Octokit }) {
           if (error.status === 403) {
             logger.error(
               "Not allowed to add a comment to the issue #%d.",
-              issue.number,
+              issue.number
             );
           } else if (error.status === 404) {
             logger.error(
               "Failed to add a comment to the issue #%d as it doesn't exist.",
-              issue.number,
+              issue.number
             );
           } else {
             errors.push(error);
             logger.error(
               "Failed to add a comment to the issue #%d.",
-              issue.number,
+              issue.number
             );
             // Don't throw right away and continue to update other issues
           }
         }
-      }),
+      })
     );
   }
 
@@ -202,7 +201,7 @@ export default async function success(pluginConfig, context, { Octokit }) {
             data: { html_url: url },
           } = await octokit.request(
             "PATCH /repos/{owner}/{repo}/issues/{issue_number}",
-            updateIssue,
+            updateIssue
           );
           logger.log("Closed issue #%d: %s.", issue.number, url);
         } catch (error) {
@@ -210,13 +209,13 @@ export default async function success(pluginConfig, context, { Octokit }) {
           logger.error("Failed to close the issue #%d.", issue.number);
           // Don't throw right away and continue to close other issues
         }
-      }),
+      })
     );
   }
 
   if (addReleases !== false && errors.length === 0) {
     const ghRelease = releases.find(
-      (release) => release.name && release.name === RELEASE_NAME,
+      (release) => release.name && release.name === RELEASE_NAME
     );
     if (!isNil(ghRelease)) {
       const ghRelaseId = ghRelease.id;
@@ -233,7 +232,7 @@ export default async function success(pluginConfig, context, { Octokit }) {
             repo,
             release_id: ghRelaseId,
             body: newBody,
-          },
+          }
         );
       }
     }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -7,7 +7,6 @@ import {
   isBoolean,
 } from "lodash-es";
 import urlJoin from "url-join";
-import AggregateError from "aggregate-error";
 
 import parseGithubUrl from "./parse-github-url.js";
 import resolveConfig from "./resolve-config.js";
@@ -30,12 +29,12 @@ const VALIDATORS = {
       isNonEmptyString(proxy) ||
       (isPlainObject(proxy) &&
         isNonEmptyString(proxy.host) &&
-        isNumber(proxy.port)),
+        isNumber(proxy.port))
   ),
   assets: isArrayOf(
     (asset) =>
       isStringOrStringArray(asset) ||
-      (isPlainObject(asset) && isStringOrStringArray(asset.path)),
+      (isPlainObject(asset) && isStringOrStringArray(asset.path))
   ),
   successComment: canBeDisabled(isNonEmptyString),
   failTitle: canBeDisabled(isNonEmptyString),
@@ -73,7 +72,7 @@ export default async function verify(pluginConfig, context, { Octokit }) {
             getError(`EINVALID${option.toUpperCase()}`, { [option]: value }),
           ]
         : errors,
-    [],
+    []
   );
 
   if (githubApiUrl) {
@@ -81,7 +80,7 @@ export default async function verify(pluginConfig, context, { Octokit }) {
   } else if (githubUrl) {
     logger.log(
       "Verify GitHub authentication (%s)",
-      urlJoin(githubUrl, githubApiPathPrefix),
+      urlJoin(githubUrl, githubApiPathPrefix)
     );
   } else {
     logger.log("Verify GitHub authentication");
@@ -101,7 +100,7 @@ export default async function verify(pluginConfig, context, { Octokit }) {
         githubApiPathPrefix,
         githubApiUrl,
         proxy,
-      }),
+      })
     );
 
     // https://github.com/semantic-release/github/issues/182

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@octokit/plugin-retry": "^7.0.0",
         "@octokit/plugin-throttling": "^9.0.0",
         "@semantic-release/error": "^4.0.0",
-        "aggregate-error": "^5.0.0",
         "debug": "^4.3.4",
         "dir-glob": "^3.0.1",
         "globby": "^14.0.0",
@@ -2201,6 +2200,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^5.2.0",
@@ -3080,6 +3080,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
       "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "5.0.0"
@@ -4800,6 +4801,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7030,6 +7032,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@octokit/plugin-retry": "^7.0.0",
     "@octokit/plugin-throttling": "^9.0.0",
     "@semantic-release/error": "^4.0.0",
-    "aggregate-error": "^5.0.0",
     "debug": "^4.3.4",
     "dir-glob": "^3.0.1",
     "globby": "^14.0.0",


### PR DESCRIPTION
ref https://github.com/semantic-release/semantic-release/discussions/3376
ref https://github.com/es-tooling/module-replacements/issues/80

As per the `package.json` `engines` of this package, `@semantic-release/github` supports Node.js `>=20.8.1`.

As per https://github.com/sindresorhus/aggregate-error

> Note: With [Node.js 15](https://medium.com/@nodejs/node-js-v15-0-0-is-here-deb00750f278), there's now a built-in [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) type.

This means we can remove the usage of this package and use the JavaScript built-in `AggregateError`.