### PR TITLE
fix(edge-case): fetching `associatedPRs` on 100+ `context.commits` in `success` lifecycle

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -261,6 +261,10 @@ function buildAssociatedPRsQuery(shas) {
             return `commit${sha.slice(0, 6)}: object(oid: "${sha}") {
             ...on Commit {
               associatedPullRequests(first: 100) {
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
                 nodes {
                   url
                   number

--- a/lib/success.js
+++ b/lib/success.js
@@ -67,32 +67,40 @@ export default async function success(pluginConfig, context, { Octokit }) {
     const releaseInfos = releases.filter((release) => Boolean(release.name));
     const shas = commits.map(({ hash }) => hash);
 
-    const { repository } = await octokit.graphql(
-      buildAssociatedPRsQuery(shas),
-      { owner, repo },
-    );
-    const responseAssociatedPRs = Object.values(repository).map(
-      (item) => item.associatedPullRequests,
-    );
-
     const associatedPRs = [];
 
-    for (const { nodes, pageInfo } of responseAssociatedPRs) {
-      associatedPRs.push(nodes);
-      if (pageInfo.hasNextPage) {
-        let cursor = pageInfo.endCursor;
-        let hasNextPage = true;
-        while (hasNextPage) {
-          const { repository } = await octokit.graphql(
-            loadSingleCommitAssociatedPRs,
-            { owner, repo, sha: response.commit.oid, cursor },
-          );
-          const { associatedPullRequests } = repository.commit;
-          associatedPRs.push(associatedPullRequests.nodes);
-          if (associatedPullRequests.pageInfo.hasNextPage) {
-            cursor = associatedPullRequests.pageInfo.endCursor;
-          } else {
-            hasNextPage = false;
+    // Split commit shas into chunks of 100 shas
+    const chunkSize = 100;
+    const shasChunks = [];
+    for (let i = 0; i < shas.length; i += chunkSize) {
+      const chunk = shas.slice(i, i + chunkSize);
+      shasChunks.push(chunk);
+    }
+    for (const chunk of shasChunks) {
+      const { repository } = await octokit.graphql(
+        buildAssociatedPRsQuery(chunk),
+        { owner, repo },
+      );
+      const responseAssociatedPRs = Object.values(repository).map(
+        (item) => item.associatedPullRequests,
+      );
+      for (const { nodes, pageInfo } of responseAssociatedPRs) {
+        associatedPRs.push(nodes);
+        if (pageInfo.hasNextPage) {
+          let cursor = pageInfo.endCursor;
+          let hasNextPage = true;
+          while (hasNextPage) {
+            const { repository } = await octokit.graphql(
+              loadSingleCommitAssociatedPRs,
+              { owner, repo, sha: response.commit.oid, cursor },
+            );
+            const { associatedPullRequests } = repository.commit;
+            associatedPRs.push(associatedPullRequests.nodes);
+            if (associatedPullRequests.pageInfo.hasNextPage) {
+              cursor = associatedPullRequests.pageInfo.endCursor;
+            } else {
+              hasNextPage = false;
+            }
           }
         }
       }

--- a/lib/success.js
+++ b/lib/success.js
@@ -280,3 +280,27 @@ function buildAssociatedPRsQuery(shas) {
   `;
 }
 
+/**
+ * GraphQL Query to fetch additional associatedPR for commits that has more than 100 associatedPRs
+ */
+const loadSingleCommitAssociatedPRs = `#graphql
+  query getCommitAssociatedPRs($owner: String!, $repo: String!, $sha: String!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      commit: object(oid: $sha) {
+        ...on Commit {
+          associatedPullRequests(after: $cursor, first: 100) {
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+            nodes {
+              url
+              number
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/lib/success.js
+++ b/lib/success.js
@@ -71,9 +71,32 @@ export default async function success(pluginConfig, context, { Octokit }) {
       buildAssociatedPRsQuery(shas),
       { owner, repo },
     );
-    const associatedPRs = Object.values(repository).map(
-      (item) => item.associatedPullRequests.nodes,
+    const responseAssociatedPRs = Object.values(repository).map(
+      (item) => item.associatedPullRequests,
     );
+
+    const associatedPRs = [];
+
+    for (const { nodes, pageInfo } of responseAssociatedPRs) {
+      associatedPRs.push(nodes);
+      if (pageInfo.hasNextPage) {
+        let cursor = pageInfo.endCursor;
+        let hasNextPage = true;
+        while (hasNextPage) {
+          const { repository } = await octokit.graphql(
+            loadSingleCommitAssociatedPRs,
+            { owner, repo, sha: response.commit.oid, cursor },
+          );
+          const { associatedPullRequests } = repository.commit;
+          associatedPRs.push(associatedPullRequests.nodes);
+          if (associatedPullRequests.pageInfo.hasNextPage) {
+            cursor = associatedPullRequests.pageInfo.endCursor;
+          } else {
+            hasNextPage = false;
+          }
+        }
+      }
+    }
 
     const uniqueAssociatedPRs = uniqBy(flatten(associatedPRs), "number");
 
@@ -260,6 +283,7 @@ function buildAssociatedPRsQuery(shas) {
           .map((sha) => {
             return `commit${sha.slice(0, 6)}: object(oid: "${sha}") {
             ...on Commit {
+              oid
               associatedPullRequests(first: 100) {
                 pageInfo {
                   endCursor

--- a/lib/success.js
+++ b/lib/success.js
@@ -252,7 +252,7 @@ export default async function success(pluginConfig, context, { Octokit }) {
  * @param {Array<string>} shas
  * @returns {string}
  */
-export function buildAssociatedPRsQuery(shas) {
+function buildAssociatedPRsQuery(shas) {
   return `#graphql
     query getAssociatedPRs($owner: String!, $repo: String!) {
       repository(owner: $owner, name: $repo) {
@@ -275,3 +275,4 @@ export function buildAssociatedPRsQuery(shas) {
     }
   `;
 }
+

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -436,7 +436,12 @@ test("Comment and add labels on PR included in the releases", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -656,7 +661,12 @@ test("Verify, release and notify success", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -809,7 +819,12 @@ test("Verify, update release and notify success", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -62,12 +62,22 @@ test("Add comment and labels to PRs associated with release commits and issues s
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
           commit456: {
+            oid: "456",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[1]],
             },
           },
@@ -232,12 +242,22 @@ test("Add comment and labels to PRs associated with release commits and issues c
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
           commit456: {
+            oid: "456",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[1]],
             },
           },
@@ -423,32 +443,62 @@ test("Make multiple search queries if necessary", async (t) => {
       data: {
         repository: {
           commitaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: {
+            oid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
           commitbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: {
+            oid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[1]],
             },
           },
           commitcccccccccccccccccccccccccccccccccccccccccc: {
+            oid: "cccccccccccccccccccccccccccccccccccccccccc",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[2]],
             },
           },
           commiteeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee: {
+            oid: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[3]],
             },
           },
           commitffffffffffffffffffffffffffffffffffffffffff: {
+            oid: "ffffffffffffffffffffffffffffffffffffffffff",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[4]],
             },
           },
           commitgggggggggggggggggggggggggggggggggggggggggg: {
+            oid: "gggggggggggggggggggggggggggggggggggggggggg",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[5]],
             },
           },
@@ -667,12 +717,22 @@ test("Do not add comment and labels for unrelated PR returned by search (compare
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
           commit456: {
+            oid: "456",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[1]],
             },
           },
@@ -769,7 +829,12 @@ test("Do not add comment and labels if no PR is associated with release commits"
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [],
             },
           },
@@ -890,17 +955,32 @@ test("Do not add comment and labels to PR/issues from other repo", async (t) => 
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [],
             },
           },
           commit456: {
+            oid: "456",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [],
             },
           },
           commit789: {
+            oid: "789",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [],
             },
           },
@@ -990,17 +1070,32 @@ test("Ignore missing and forbidden issues/PRs", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
           commit456: {
+            oid: "456",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[1]],
             },
           },
           commit789: {
+            oid: "789",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[2]],
             },
           },
@@ -1159,7 +1254,12 @@ test("Add custom comment and labels", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -1254,7 +1354,12 @@ test("Add custom label", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -1344,7 +1449,12 @@ test("Comment on issue/PR without ading a label", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -1437,7 +1547,12 @@ test("Editing the release to include all release links at the bottom", async (t)
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -1541,7 +1656,12 @@ test("Editing the release to include all release links at the top", async (t) =>
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -1642,7 +1762,12 @@ test("Editing the release to include all release links with no additional releas
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -1732,7 +1857,12 @@ test("Editing the release to include all release links with no additional releas
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -1815,7 +1945,12 @@ test("Editing the release to include all release links with no releases", async 
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -1900,7 +2035,12 @@ test("Editing the release with no ID in the release", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
@@ -1990,12 +2130,22 @@ test("Ignore errors when adding comments and closing issues", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[0]],
             },
           },
           commit456: {
+            oid: "456",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [prs[1]],
             },
           },
@@ -2123,7 +2273,12 @@ test("Close open issues when a release is successful", async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [],
             },
           },
@@ -2274,7 +2429,12 @@ test('Skip closing issues if "failComment" is "false"', async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [],
             },
           },
@@ -2325,7 +2485,12 @@ test('Skip closing issues if "failTitle" is "false"', async (t) => {
       data: {
         repository: {
           commit123: {
+            oid: "123",
             associatedPullRequests: {
+              pageInfo: {
+                endCursor: "NI",
+                hasNextPage: false,
+              },
               nodes: [],
             },
           },


### PR DESCRIPTION
This Pull Request addresses the following edge cases in our consumption of GraphQL at fetching `associatedPRs` for `context.commits` list in the `success` lifecycle of the plugin.

### 1.  Fetching `associatedPRs` for 100+ `context.commits`

We currently use GraphQL Fragments to query `associatedPRs` for each commit in the `context.commits` array, this grants us the ability to get `associatedPRs` for alot of commits by making just one request. BUT, we are limited to a fragment of only 100 items which means that we can only query `associatedPRs` for 100 commits in one request, and needing to make another request for the next set of 100 incases where there's more than 100.

**THE FIX**: Implemented logic to split the `context.commits` array into chunks of 100 items, which is then consumed by the `buildAssociatedPRsQuery` utils that builds the GraphQL query fragment, requests the `associatedPRs` per chunk and ends up merging/consolidating all response nodes from each chunks into on final array of `associatedPRs` 

### 2. When `associatedPRs` response nodes is more than 100 (kinda unlikely, but wouldn't hurt to address 🤔)

When `associatedPRs` are fetched for each commit, there's a possibility that the response items is more than 100 🫣. Important to note that "Maximum response nodes is 100 items with the rest paginated" this means we can only get back 100 nodes and the rest split to another page of 100 max nodes.

**THE FIX**: Implemented a second graphQL query ` loadSingleCommitAssociatedPRs` (seen below) which is used to fetch the next page in a paginated response for individual associatedPRs. This is made possible with the `pageInfo` value in the response object, which triggers a call to this query if initial response `hasNextPage` is `true` and uses the `endCursor` value as the starting point for next response nodes to fetch.

```js
const loadSingleCommitAssociatedPRs = `#graphql
  query getCommitAssociatedPRs($owner: String!, $repo: String!, $sha: String!, $cursor: String) {
    repository(owner: $owner, name: $repo) {
      commit: object(oid: $sha) {
        ...on Commit {
          associatedPullRequests(after: $cursor, first: 1) {
            pageInfo {
              endCursor
              hasNextPage
            }
            nodes {
              url
              number
              body
            }
          }
        }
      }
    }
  }
`;
```  

Important to state that this logic is consumed inside each `context.commits` chunks to consolidate the paginated `associatedPRs` response node in the final `associatedPRs` array.

### Related Issue

Fixes #868

### Screencast/Screenshot

**Demo (Setting `chunk-size` and graphql query page request size property `first` to `1`)**

https://github.com/user-attachments/assets/0a7f32d4-cbab-4379-a805-d521ade6f294
