### PR TITLE
fix: `max_node_limit_exceeded` error when fetching associatedPRs

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -373,7 +373,7 @@ const baseFields = `
   }
   authorAssociation
   activeLockReason
-  labels(first: 100) {
+  labels(first: 40) {
     nodes {
       id
       url


### PR DESCRIPTION
The PR addressed the issue where we our graphql query that fetches associatedPRs hits a case where it requests for 1million plus nodes exceeding the GitHub Node Limits size. It does this by simply reducing the number of `labels` requested per associatedPRs reducing the maximum possible requests to `410,000` just right below `500,000` which is GitHub's maximum Node Limit size.

**Changes Made:**

- Updated the `first` value in the `baseField` constant from `100` to `40` for all graphql request that consumes it 😁 

### Related Issues

Fixes #911