### PR TITLE
fix(glob-assets): remove unnecessary option when invoking `globby()`

### DIFF
--- a/lib/glob-assets.js
+++ b/lib/glob-assets.js
@@ -30,7 +30,6 @@ export default async function globAssets({ cwd }, assets) {
           const globbed = await globby(glob, {
             cwd,
             expandDirectories: false, // TODO Temporary workaround for https://github.com/mrmlnc/fast-glob/issues/47
-            gitignore: false,
             dot: true,
             onlyFiles: false,
           });


### PR DESCRIPTION
# 📖 Description
remove unnecessary option when invoking `globby()`: `gitignore: false`

# 📚 Context
The default behaviour of `gitignore` option is `false`[^1]

[^1]: https://github.com/sindresorhus/globby?tab=readme-ov-file#gitignore
