### PR TITLE
chore: drop aggregate-error dependency in favor of native object

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -1,6 +1,5 @@
 import { isNil, uniqBy, template, flatten, isEmpty, merge } from "lodash-es";
 import pFilter from "p-filter";
-import AggregateError from "aggregate-error";
 import issueParser from "issue-parser";
 import debugFactory from "debug";
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -7,7 +7,6 @@ import {
   isBoolean,
 } from "lodash-es";
 import urlJoin from "url-join";
-import AggregateError from "aggregate-error";
 
 import parseGithubUrl from "./parse-github-url.js";
 import resolveConfig from "./resolve-config.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@octokit/plugin-retry": "^7.0.0",
         "@octokit/plugin-throttling": "^9.0.0",
         "@semantic-release/error": "^4.0.0",
-        "aggregate-error": "^5.0.0",
         "debug": "^4.3.4",
         "dir-glob": "^3.0.1",
         "globby": "^14.0.0",
@@ -2141,6 +2140,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^5.2.0",
@@ -3007,6 +3007,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
       "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "5.0.0"
@@ -4617,6 +4618,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5920,6 +5922,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@octokit/plugin-retry": "^7.0.0",
     "@octokit/plugin-throttling": "^9.0.0",
     "@semantic-release/error": "^4.0.0",
-    "aggregate-error": "^5.0.0",
     "debug": "^4.3.4",
     "dir-glob": "^3.0.1",
     "globby": "^14.0.0",


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/mcmxcdev'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/mcmxcdev/tally.svg'></a>

## Changes
- uninstall `aggregate-error` dependency
- remove `AggregateError` import from `success.js` and `verify.js` files

## Motivation
https://www.npmjs.com/package/aggregate-error notes that "With [Node.js 15](https://medium.com/@nodejs/node-js-v15-0-0-is-here-deb00750f278), there's now a built-in [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) type."

Since this package specifies `"node": ">=20.8.1"` as engines requirement, we should be able to drop this dependency without any issues. 