### PR TITLE
chore: drop cpy dependency in favor of native node:fs functionality

### DIFF
--- a/lib/cpy.js
+++ b/lib/cpy.js
@@ -1,0 +1,19 @@
+import { copyFile, mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+export default async function cpy(src, dest) {
+  await mkdir(dest, { recursive: true });
+
+  const entries = await readdir(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      await cpy(srcPath, destPath);
+    } else {
+      await copyFile(srcPath, destPath);
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
       "devDependencies": {
         "ava": "6.1.3",
         "c8": "10.1.2",
-        "cpy": "11.1.0",
         "cz-conventional-changelog": "3.3.0",
         "fetch-mock": "npm:@gr2m/fetch-mock@9.11.0-pull-request-644.1",
         "lockfile-lint": "4.14.0",
@@ -3657,23 +3656,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/copy-file": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/copy-file/-/copy-file-11.0.0.tgz",
-      "integrity": "sha512-mFsNh/DIANLqFt5VHZoGirdg7bK5+oTWlhnGu6tgRhzBlnEKWaPX2xrFaLltii/6rmhqFMJqffUgknuRdpYlHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.11",
-        "p-event": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/core-js": {
       "version": "3.38.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
@@ -3737,27 +3719,6 @@
         "@types/node": "*",
         "cosmiconfig": ">=8.2",
         "typescript": ">=4"
-      }
-    },
-    "node_modules/cpy": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/cpy/-/cpy-11.1.0.tgz",
-      "integrity": "sha512-QGHetPSSuprVs+lJmMDcivvrBwTKASzXQ5qxFvRC2RFESjjod71bDvFvhxTjDgkNjrrb72AI6JPjfYwxrIy33A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "copy-file": "^11.0.0",
-        "globby": "^14.0.2",
-        "junk": "^4.0.1",
-        "micromatch": "^4.0.7",
-        "p-filter": "^4.1.0",
-        "p-map": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cross-spawn": {
@@ -6944,19 +6905,6 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
-    },
-    "node_modules/junk": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
-      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/just-diff": {
       "version": "6.0.2",
@@ -12228,22 +12176,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-event": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
-      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-filter": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
@@ -12321,19 +12253,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
-      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "ava": "6.1.3",
     "c8": "10.1.2",
-    "cpy": "11.1.0",
     "cz-conventional-changelog": "3.3.0",
     "fetch-mock": "npm:@gr2m/fetch-mock@9.11.0-pull-request-644.1",
     "lockfile-lint": "4.14.0",

--- a/test/glob-assets.test.js
+++ b/test/glob-assets.test.js
@@ -4,9 +4,9 @@ import { mkdir } from "node:fs/promises";
 import test from "ava";
 import { isPlainObject, sortBy } from "lodash-es";
 import { temporaryDirectory } from "tempy";
-import cpy from "cpy";
 
 import globAssets from "../lib/glob-assets.js";
+import cpy from "../lib/cpy.js";
 
 const sortAssets = (assets) =>
   sortBy(assets, (asset) => (isPlainObject(asset) ? asset.path : asset));
@@ -15,7 +15,7 @@ const fixtures = "test/fixtures/files";
 
 test("Retrieve file from single path", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, ["upload.txt"]);
 
   t.deepEqual(globbedAssets, ["upload.txt"]);
@@ -23,7 +23,7 @@ test("Retrieve file from single path", async (t) => {
 
 test("Retrieve multiple files from path", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     "upload.txt",
     "upload_other.txt",
@@ -37,7 +37,7 @@ test("Retrieve multiple files from path", async (t) => {
 
 test("Include missing files as defined, using Object definition", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     "upload.txt",
     { path: "miss*.txt", label: "Missing" },
@@ -51,7 +51,7 @@ test("Include missing files as defined, using Object definition", async (t) => {
 
 test("Retrieve multiple files from Object", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     { path: "upload.txt", name: "upload_name", label: "Upload label" },
     "upload_other.txt",
@@ -68,7 +68,7 @@ test("Retrieve multiple files from Object", async (t) => {
 
 test("Retrieve multiple files without duplicates", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     "upload_other.txt",
     "upload.txt",
@@ -86,7 +86,7 @@ test("Retrieve multiple files without duplicates", async (t) => {
 
 test("Favor Object over String values when removing duplicates", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     "upload_other.txt",
     "upload.txt",
@@ -108,7 +108,7 @@ test("Favor Object over String values when removing duplicates", async (t) => {
 
 test("Retrieve file from single glob", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, ["upload.*"]);
 
   t.deepEqual(globbedAssets, ["upload.txt"]);
@@ -116,7 +116,7 @@ test("Retrieve file from single glob", async (t) => {
 
 test("Retrieve multiple files from single glob", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, ["*.txt"]);
 
   t.deepEqual(
@@ -127,7 +127,7 @@ test("Retrieve multiple files from single glob", async (t) => {
 
 test("Accept glob array with one value", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     ["*load.txt"],
     ["*_other.txt"],
@@ -141,7 +141,7 @@ test("Accept glob array with one value", async (t) => {
 
 test("Include globs that resolve to no files as defined", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     ["upload.txt", "!upload.txt"],
   ]);
@@ -154,7 +154,7 @@ test("Include globs that resolve to no files as defined", async (t) => {
 
 test("Accept glob array with one value for missing files", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     ["*missing.txt"],
     ["*_other.txt"],
@@ -168,7 +168,7 @@ test("Accept glob array with one value for missing files", async (t) => {
 
 test("Replace name by filename for Object that match multiple files", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     { path: "*.txt", name: "upload_name", label: "Upload label" },
   ]);
@@ -188,7 +188,7 @@ test("Replace name by filename for Object that match multiple files", async (t) 
 
 test("Include dotfiles", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [".dot*"]);
 
   t.deepEqual(globbedAssets, [".dotfile"]);
@@ -196,7 +196,7 @@ test("Include dotfiles", async (t) => {
 
 test("Ingnore single negated glob", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, ["!*.txt"]);
 
   t.deepEqual(globbedAssets, []);
@@ -204,7 +204,7 @@ test("Ingnore single negated glob", async (t) => {
 
 test("Ingnore single negated glob in Object", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [{ path: "!*.txt" }]);
 
   t.deepEqual(globbedAssets, []);
@@ -212,7 +212,7 @@ test("Ingnore single negated glob in Object", async (t) => {
 
 test("Accept negated globs", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     ["*.txt", "!**/*_other.txt"],
   ]);
@@ -222,7 +222,7 @@ test("Accept negated globs", async (t) => {
 
 test("Expand directories", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, resolve(cwd, "dir"), { dot: true });
+  await cpy(fixtures, resolve(cwd, "dir"));
   const globbedAssets = await globAssets({ cwd }, [["dir"]]);
 
   t.deepEqual(
@@ -238,7 +238,7 @@ test("Expand directories", async (t) => {
 
 test("Include empty temporaryDirectory as defined", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   await mkdir(resolve(cwd, "empty"), { recursive: true });
   const globbedAssets = await globAssets({ cwd }, [["empty"]]);
 
@@ -247,7 +247,7 @@ test("Include empty temporaryDirectory as defined", async (t) => {
 
 test("Deduplicate resulting files path", async (t) => {
   const cwd = temporaryDirectory();
-  await cpy(fixtures, cwd, { dot: true });
+  await cpy(fixtures, cwd);
   const globbedAssets = await globAssets({ cwd }, [
     "./upload.txt",
     resolve(cwd, "upload.txt"),


### PR DESCRIPTION
## Changes
- uninstall `cpy` dependency
- add `cpy.js` utility file to `lib` folder
- replace `cpy` import with custom `cpy.js` utility file functionality in `glob-assets.test.js`

## Motivation
Closes https://github.com/es-tooling/ecosystem-cleanup/issues/124