### PR TITLE
ci: skip tests for commits that only change markdown files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ name: Test
     branches:
       - master
       - renovate/**
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
### Change Summary
Currently, the `Test` CI workflow will run even when a push changes **only markdown files** (e.g., README.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see below for quantity).

### Example
Here is an example of the behaviour described above: the commit [`9d7b95f`](https://github.com/semantic-release/github/commit/9d7b95ff62ad5e76879fa8e77d546dfd1fa9b871) changed these files: `README.md` and, when pushed, triggered [this](https://github.com/semantic-release/github/actions/runs/14274658486) workflow run, which ran for ~7 CPU minutes. With the proposed changes, these 7 CPU minutes would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general. 

Note that this is a single example out of 4 examples over the last few months; a lower estimate for the accumulated gain is **30 CPU minutes**, but the overall number could be **higher** because our cutoff date is late May and our data go only a few months back.

This only affects the `push` trigger and not the `pull_request` trigger, so the actions related to pull requests (opening, pushing new commits on an open PR, closing) will not be affected, only the pushes to branches which do not have an open pull request.

<details>
<summary>Click here to see all the recent CI runs triggered by markdown files.</summary>

[commit 9d7b95f](https://github.com/semantic-release/github/commit/9d7b95f) => [run url](https://github.com/semantic-release/github/actions/runs/14274658486)
[commit aa78397](https://github.com/semantic-release/github/commit/aa78397) => [run url](https://github.com/semantic-release/github/actions/runs/14476462717)
[commit 55cd34f](https://github.com/semantic-release/github/commit/55cd34f) => [run url](https://github.com/semantic-release/github/actions/runs/10180493294)
[commit df69c49](https://github.com/semantic-release/github/commit/df69c49) => [run url](https://github.com/semantic-release/github/actions/runs/13729783031)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on optimizations in GitHub Actions workflows.

Thanks for your time on this.

Kindly let us know (here or in the email below) if you would like to ignore other file types or apply the filter to other workflows/triggers, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch