### PR TITLE
fix(success): check failCommentCondition before closing issues

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -265,6 +265,11 @@ export default async function success(pluginConfig, context, { Octokit }) {
 
   if (failComment === false || failTitle === false) {
     logger.log("Skip closing issue.");
+    logger.warn(
+      `DEPRECATION: 'false' for 'failComment' or 'failTitle' is deprecated and will be removed in a future major version. Use 'failCommentCondition' instead.`,
+    );
+  } else if (failCommentCondition === false) {
+    logger.log("Skip closing issue.");
   } else {
     const srIssues = await findSRIssues(
       octokit,


### PR DESCRIPTION
Hi everybody,

I noticed the deprecation warning that `failComment=false` shouldn't be used anymore. However, using `failCommentCondition=false` isn't checked before closing issues.

This leads to unexpected error logs and pipeline runs that show up as failed.

I tried to follow the contribution guidelines of semantic-release/semantic-release. If you expect a different format of contributions please let me know.