### PR TITLE
docs: correct workflow test.yml Build Status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [**semantic-release**](https://github.com/semantic-release/semantic-release) plugin to publish a
 [GitHub release](https://help.github.com/articles/about-releases) and comment on released Pull Requests/Issues.
 
-[![Build Status](https://github.com/semantic-release/github/workflows/Test/badge.svg)](https://github.com/semantic-release/github/actions?query=workflow%3ATest+branch%3Amaster)
+[![Build Status](https://github.com/semantic-release/github/actions/workflows/test.yml/badge.svg)](https://github.com/semantic-release/github/actions/workflows/test.yml?query=branch%3Amaster)
 
 [![npm latest version](https://img.shields.io/npm/v/@semantic-release/github/latest.svg)](https://www.npmjs.com/package/@semantic-release/github)
 [![npm next version](https://img.shields.io/npm/v/@semantic-release/github/next.svg)](https://www.npmjs.com/package/@semantic-release/github)


### PR DESCRIPTION
## Situation

The [README](https://github.com/semantic-release/github/blob/master/README.md) badge for the Build Status workflow "Test" is permanently showing "failing".

<img width="794" height="205" alt="image" src="https://github.com/user-attachments/assets/29aa681f-b3db-4735-90d4-7034e4743ed5" />

The URL used for the badge is https://github.com/semantic-release/github/workflows/Test/badge.svg

The workflow is [.github/workflows/test.yml](https://github.com/semantic-release/github/blob/master/.github/workflows/test.yml) and the default branch is `master`.

The correct syntax for displaying a GitHub Actions workflow syntax is documented in [Adding a workflow status badge](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge)

## Change

The badge URL is changed to

https://github.com/semantic-release/github/actions/workflows/test.yml/badge.svg to display the status of the workflow [.github/workflows/test.yml](https://github.com/semantic-release/github/blob/master/.github/workflows/test.yml) in the default `master` branch.

the workflow link is changed to

https://github.com/semantic-release/github/actions/workflows/test.yml?query=branch%3Amaster

