### PR TITLE
chore(deps): upgrade fetch-mock to v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "c8": "12.0.0",
         "cpy": "13.2.2",
         "cz-conventional-changelog": "3.3.0",
-        "fetch-mock": "npm:@gr2m/fetch-mock@9.11.0-pull-request-644.1",
+        "fetch-mock": "12.6.0",
         "lockfile-lint": "5.0.1",
         "ls-engines": "0.10.1",
         "npm-run-all2": "9.0.3",
@@ -113,257 +113,12 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -540,28 +295,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1827,6 +1560,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/glob-to-regexp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@types/glob-to-regexp/-/glob-to-regexp-0.4.4.tgz",
+      "integrity": "sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2314,19 +2054,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.10.42",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -2409,40 +2136,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/buffer": {
@@ -2608,27 +2301,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001800",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
     },
     "node_modules/cbor2": {
       "version": "2.3.0",
@@ -3409,18 +3081,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -3814,6 +3474,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -3943,13 +3613,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.387",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
-      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "2.0.0",
@@ -4539,39 +4202,19 @@
       }
     },
     "node_modules/fetch-mock": {
-      "name": "@gr2m/fetch-mock",
-      "version": "9.11.0-pull-request-644.1",
-      "resolved": "https://registry.npmjs.org/@gr2m/fetch-mock/-/fetch-mock-9.11.0-pull-request-644.1.tgz",
-      "integrity": "sha512-gTp6RCHzlOXS1qRb0APfuyz48Lw/JFPa4uiar+kEgL1STsDwth75HJZ4x30tBlXMJXV8XDTDzJ2Hz9w3RWiHJA==",
-      "deprecated": "The fix has been implemented in fetch-mock@10",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-12.6.0.tgz",
+      "integrity": "sha512-oAy0OqAvjAvduqCeWveBix7LLuDbARPqZZ8ERYtBcCURA3gy7EALA3XWq0tCNxsSg+RmmJqyaeeZlOCV9abv6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.0.0",
-        "@babel/runtime": "^7.0.0",
-        "core-js": "^3.0.0",
-        "debug": "^4.1.1",
-        "glob-to-regexp": "^0.4.0",
-        "is-subset": "^0.1.1",
-        "lodash.isequal": "^4.5.0",
-        "path-to-regexp": "^2.2.1",
-        "querystring": "^0.2.0",
-        "whatwg-url": "^6.5.0"
+        "@types/glob-to-regexp": "^0.4.4",
+        "dequal": "^2.0.3",
+        "glob-to-regexp": "^0.4.1",
+        "regexparam": "^3.0.0"
       },
       "engines": {
-        "node": ">=4.0.0"
-      },
-      "funding": {
-        "type": "charity",
-        "url": "https://www.justgiving.com/refugee-support-europe"
-      },
-      "peerDependencies": {
-        "node-fetch": "*"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
+        "node": ">=18.11.0"
       }
     },
     "node_modules/figures": {
@@ -4825,16 +4468,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -6118,13 +5751,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-symbol": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
@@ -6365,19 +5991,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/json-file-plus": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/json-file-plus/-/json-file-plus-4.0.1.tgz",
@@ -6433,19 +6046,6 @@
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
@@ -6729,14 +6329,6 @@
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "license": "MIT"
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -6753,13 +6345,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6847,16 +6432,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
       }
     },
     "node_modules/ls-engines": {
@@ -7548,16 +7123,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/node.extend": {
@@ -10275,13 +9840,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -10615,27 +10173,6 @@
         "url": "https://bjornlu.com/sponsor"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10892,6 +10429,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
+      "integrity": "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/registry-auth-token": {
@@ -12423,16 +11970,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/traverse": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
@@ -12711,37 +12248,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
     "node_modules/url-join": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
@@ -12832,13 +12338,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/well-known-symbols": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
@@ -12847,18 +12346,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/which": {
@@ -13078,13 +12565,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "18.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "c8": "12.0.0",
     "cpy": "13.2.2",
     "cz-conventional-changelog": "3.3.0",
-    "fetch-mock": "npm:@gr2m/fetch-mock@9.11.0-pull-request-644.1",
+    "fetch-mock": "12.6.0",
     "lockfile-lint": "5.0.1",
     "ls-engines": "0.10.1",
     "npm-run-all2": "9.0.3",

--- a/test/add-channel.test.js
+++ b/test/add-channel.test.js
@@ -34,15 +34,16 @@ test("Update a release", async (t) => {
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
   const releaseId = 1;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(
+  const fm = fetchMock
+    .createInstance()
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       {
         id: releaseId,
       },
+      { repeat: 1 },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       {
         html_url: releaseUrl,
@@ -53,6 +54,7 @@ test("Update a release", async (t) => {
           name: nextRelease.name,
           prerelease: false,
         },
+        repeat: 1,
       },
     );
 
@@ -68,7 +70,7 @@ test("Update a release", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -78,7 +80,7 @@ test("Update a release", async (t) => {
     "Updated GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Update a maintenance release", async (t) => {
@@ -96,15 +98,16 @@ test("Update a maintenance release", async (t) => {
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
   const releaseId = 1;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(
+  const fm = fetchMock
+    .createInstance()
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       {
         id: releaseId,
       },
+      { repeat: 1 },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       {
         html_url: releaseUrl,
@@ -115,6 +118,7 @@ test("Update a maintenance release", async (t) => {
           name: nextRelease.name,
           prerelease: false,
         },
+        repeat: 1,
       },
     );
 
@@ -130,7 +134,7 @@ test("Update a maintenance release", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -140,7 +144,7 @@ test("Update a maintenance release", async (t) => {
     "Updated GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Update a prerelease", async (t) => {
@@ -157,15 +161,16 @@ test("Update a prerelease", async (t) => {
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
   const releaseId = 1;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(
+  const fm = fetchMock
+    .createInstance()
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       {
         id: releaseId,
       },
+      { repeat: 1 },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       {
         html_url: releaseUrl,
@@ -176,6 +181,7 @@ test("Update a prerelease", async (t) => {
           name: nextRelease.name,
           prerelease: false,
         },
+        repeat: 1,
       },
     );
 
@@ -191,7 +197,7 @@ test("Update a prerelease", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -201,7 +207,7 @@ test("Update a prerelease", async (t) => {
     "Updated GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Update a release with a custom github url", async (t) => {
@@ -222,15 +228,16 @@ test("Update a release with a custom github url", async (t) => {
   const releaseUrl = `${env.GH_URL}/${owner}/${repo}/releases/${nextRelease.version}`;
   const releaseId = 1;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(
+  const fm = fetchMock
+    .createInstance()
+    .get(
       `https://othertesturl.com:443/prefix/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       {
         id: releaseId,
       },
+      { repeat: 1 },
     )
-    .patchOnce(
+    .patch(
       `https://othertesturl.com:443/prefix/repos/${owner}/${repo}/releases/${releaseId}`,
       {
         html_url: releaseUrl,
@@ -241,6 +248,7 @@ test("Update a release with a custom github url", async (t) => {
           name: nextRelease.name,
           prerelease: false,
         },
+        repeat: 1,
       },
     );
 
@@ -256,7 +264,7 @@ test("Update a release with a custom github url", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -266,7 +274,7 @@ test("Update a release with a custom github url", async (t) => {
     "Updated GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Create the new release if current one is missing", async (t) => {
@@ -282,13 +290,14 @@ test("Create the new release if current one is missing", async (t) => {
   const options = { repositoryUrl: `https://github.com/${owner}/${repo}.git` };
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(
+  const fm = fetchMock
+    .createInstance()
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       404,
+      { repeat: 1 },
     )
-    .postOnce(
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       {
         html_url: releaseUrl,
@@ -300,6 +309,7 @@ test("Create the new release if current one is missing", async (t) => {
           body: nextRelease.notes,
           prerelease: false,
         },
+        repeat: 1,
       },
     );
 
@@ -315,7 +325,7 @@ test("Create the new release if current one is missing", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -329,7 +339,7 @@ test("Create the new release if current one is missing", async (t) => {
     "Published GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Throw error if cannot read current release", async (t) => {
@@ -344,11 +354,12 @@ test("Throw error if cannot read current release", async (t) => {
   };
   const options = { repositoryUrl: `https://github.com/${owner}/${repo}.git` };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(
+  const fm = fetchMock
+    .createInstance()
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       500,
+      { repeat: 1 },
     );
 
   const error = await t.throwsAsync(
@@ -364,14 +375,14 @@ test("Throw error if cannot read current release", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
   t.is(error.status, 500);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Throw error if cannot create missing current release", async (t) => {
@@ -388,19 +399,21 @@ test("Throw error if cannot create missing current release", async (t) => {
     repositoryUrl: `https://github.com/${owner}/${repo}.git`,
   };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(
+  const fm = fetchMock
+    .createInstance()
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       404,
+      { repeat: 1 },
     )
-    .postOnce(`https://api.github.local/repos/${owner}/${repo}/releases`, 500, {
+    .post(`https://api.github.local/repos/${owner}/${repo}/releases`, 500, {
       body: {
         tag_name: nextRelease.gitTag,
         name: nextRelease.name,
         body: nextRelease.notes,
         prerelease: false,
       },
+      repeat: 1,
     });
 
   const error = await t.throwsAsync(
@@ -416,14 +429,14 @@ test("Throw error if cannot create missing current release", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
   t.is(error.status, 500);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Throw error if cannot update release", async (t) => {
@@ -439,13 +452,14 @@ test("Throw error if cannot update release", async (t) => {
   const options = { repositoryUrl: `https://github.com/${owner}/${repo}.git` };
   const releaseId = 1;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(
+  const fm = fetchMock
+    .createInstance()
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       { id: releaseId },
+      { repeat: 1 },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       404,
       {
@@ -454,6 +468,7 @@ test("Throw error if cannot update release", async (t) => {
           name: nextRelease.name,
           prerelease: false,
         },
+        repeat: 1,
       },
     );
 
@@ -470,12 +485,12 @@ test("Throw error if cannot update release", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
   t.is(error.status, 404);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });

--- a/test/find-sr-issue.test.js
+++ b/test/find-sr-issue.test.js
@@ -29,18 +29,20 @@ test("Filter out issues without ID", async (t) => {
     { number: 3, body: `Issue 3 body\n\n${ISSUE_ID}`, title },
   ];
 
-  const fetch = fetchMock
-    .sandbox()
-    .postOnce("https://api.github.local/graphql", {
+  const fm = fetchMock.createInstance().post(
+    "https://api.github.local/graphql",
+    {
       data: {
         repository: {
           issues: { nodes: issues },
         },
       },
-    });
+    },
+    { repeat: 1 },
+  );
 
   const srIssues = await findSRIssues(
-    new TestOctokit({ request: { fetch } }),
+    new TestOctokit({ request: { fetch: fm.fetchHandler } }),
     t.context.logger,
     title,
     labels,
@@ -61,7 +63,7 @@ test("Filter out issues without ID", async (t) => {
     },
   ]);
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Return empty array if not issues found", async (t) => {
@@ -69,18 +71,20 @@ test("Return empty array if not issues found", async (t) => {
   const repo = "test_repo";
   const title = "The automated release is failing 🚨";
   const labels = [];
-  const fetch = fetchMock
-    .sandbox()
-    .postOnce("https://api.github.local/graphql", {
+  const fm = fetchMock.createInstance().post(
+    "https://api.github.local/graphql",
+    {
       data: {
         repository: {
           issues: { nodes: [] },
         },
       },
-    });
+    },
+    { repeat: 1 },
+  );
 
   const srIssues = await findSRIssues(
-    new TestOctokit({ request: { fetch } }),
+    new TestOctokit({ request: { fetch: fm.fetchHandler } }),
     t.context.logger,
     title,
     labels,
@@ -90,7 +94,7 @@ test("Return empty array if not issues found", async (t) => {
 
   t.deepEqual(srIssues, []);
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Return empty array if not issues has matching ID", async (t) => {
@@ -102,18 +106,20 @@ test("Return empty array if not issues has matching ID", async (t) => {
     { number: 1, body: "Issue 1 body", title },
     { number: 2, body: "Issue 2 body", title },
   ];
-  const fetch = fetchMock
-    .sandbox()
-    .postOnce("https://api.github.local/graphql", {
+  const fm = fetchMock.createInstance().post(
+    "https://api.github.local/graphql",
+    {
       data: {
         repository: {
           issues: { nodes: issues },
         },
       },
-    });
+    },
+    { repeat: 1 },
+  );
 
   const srIssues = await findSRIssues(
-    new TestOctokit({ request: { fetch } }),
+    new TestOctokit({ request: { fetch: fm.fetchHandler } }),
     t.context.logger,
     title,
     labels,
@@ -122,5 +128,5 @@ test("Return empty array if not issues has matching ID", async (t) => {
   );
 
   t.deepEqual(srIssues, []);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -30,41 +30,8 @@ test("Verify GitHub auth", async (t) => {
     repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`,
   };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
-      permissions: {
-        push: true,
-      },
-      clone_url: `https://api.github.local/${owner}/${repo}.git`,
-    });
-
-  await t.notThrowsAsync(
-    t.context.m.verifyConditions(
-      {},
-      { cwd, env, options, logger: t.context.logger },
-      {
-        Octokit: TestOctokit.defaults((options) => ({
-          ...options,
-          request: { ...options.request, fetch },
-        })),
-      },
-    ),
-  );
-
-  t.true(fetch.done());
-});
-
-test("Verify GitHub auth with publish options", async (t) => {
-  const owner = "test_user";
-  const repo = "test_repo";
-  const env = { GITHUB_TOKEN: "github_token" };
-  const options = {
-    publish: { path: "@semantic-release/github" },
-    repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`,
-  };
-  const fetch = fetchMock
-    .sandbox()
+  const fm = fetchMock
+    .createInstance()
     .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
@@ -79,13 +46,46 @@ test("Verify GitHub auth with publish options", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
+});
+
+test("Verify GitHub auth with publish options", async (t) => {
+  const owner = "test_user";
+  const repo = "test_repo";
+  const env = { GITHUB_TOKEN: "github_token" };
+  const options = {
+    publish: { path: "@semantic-release/github" },
+    repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`,
+  };
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
+      permissions: {
+        push: true,
+      },
+      clone_url: `https://api.github.local/${owner}/${repo}.git`,
+    });
+
+  await t.notThrowsAsync(
+    t.context.m.verifyConditions(
+      {},
+      { cwd, env, options, logger: t.context.logger },
+      {
+        Octokit: TestOctokit.defaults((options) => ({
+          ...options,
+          request: { ...options.request, fetch: fm.fetchHandler },
+        })),
+      },
+    ),
+  );
+
+  t.true(fm.callHistory.done());
 });
 
 test("Verify GitHub auth and assets config", async (t) => {
@@ -103,9 +103,9 @@ test("Verify GitHub auth and assets config", async (t) => {
     publish: [{ path: "@semantic-release/npm" }],
     repositoryUrl: `git+https://othertesturl.com/${owner}/${repo}.git`,
   };
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -119,13 +119,13 @@ test("Verify GitHub auth and assets config", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Throw SemanticReleaseError if invalid config", async (t) => {
@@ -161,7 +161,7 @@ test("Throw SemanticReleaseError if invalid config", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -200,15 +200,19 @@ test("Publish a release without assets on a main release branch", async (t) => {
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
   const releaseId = 1;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
-      permissions: {
-        push: true,
+  const fm = fetchMock
+    .createInstance()
+    .get(
+      `https://api.github.local/repos/${owner}/${repo}`,
+      {
+        permissions: {
+          push: true,
+        },
+        clone_url: `https://api.github.local/${owner}/${repo}.git`,
       },
-      clone_url: `https://api.github.local/${owner}/${repo}.git`,
-    })
-    .postOnce(
+      { repeat: 1 },
+    )
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       { html_url: releaseUrl, id: releaseId },
       {
@@ -219,6 +223,7 @@ test("Publish a release without assets on a main release branch", async (t) => {
           prerelease: false,
           make_latest: "true",
         },
+        repeat: 1,
       },
     );
 
@@ -235,7 +240,7 @@ test("Publish a release without assets on a main release branch", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -245,7 +250,7 @@ test("Publish a release without assets on a main release branch", async (t) => {
   t.is(result.id, releaseId);
   t.deepEqual(t.context.log.args[0], ["Verify GitHub authentication"]);
   t.true(t.context.log.calledWith("Published GitHub release: %s", releaseUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release without assets on a non-main release branch", async (t) => {
@@ -261,15 +266,19 @@ test("Publish a release without assets on a non-main release branch", async (t) 
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
   const releaseId = 1;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
-      permissions: {
-        push: true,
+  const fm = fetchMock
+    .createInstance()
+    .get(
+      `https://api.github.local/repos/${owner}/${repo}`,
+      {
+        permissions: {
+          push: true,
+        },
+        clone_url: `https://api.github.local/${owner}/${repo}.git`,
       },
-      clone_url: `https://api.github.local/${owner}/${repo}.git`,
-    })
-    .postOnce(
+      { repeat: 1 },
+    )
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       { html_url: releaseUrl, id: releaseId },
       {
@@ -280,6 +289,7 @@ test("Publish a release without assets on a non-main release branch", async (t) 
           prerelease: true,
           make_latest: "false",
         },
+        repeat: 1,
       },
     );
 
@@ -296,7 +306,7 @@ test("Publish a release without assets on a non-main release branch", async (t) 
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -306,7 +316,7 @@ test("Publish a release without assets on a non-main release branch", async (t) 
   t.is(result.id, releaseId);
   t.deepEqual(t.context.log.args[0], ["Verify GitHub authentication"]);
   t.true(t.context.log.calledWith("Published GitHub release: %s", releaseUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release without assets on a maintenance branch", async (t) => {
@@ -322,15 +332,19 @@ test("Publish a release without assets on a maintenance branch", async (t) => {
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
   const releaseId = 1;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
-      permissions: {
-        push: true,
+  const fm = fetchMock
+    .createInstance()
+    .get(
+      `https://api.github.local/repos/${owner}/${repo}`,
+      {
+        permissions: {
+          push: true,
+        },
+        clone_url: `https://api.github.local/${owner}/${repo}.git`,
       },
-      clone_url: `https://api.github.local/${owner}/${repo}.git`,
-    })
-    .postOnce(
+      { repeat: 1 },
+    )
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       { html_url: releaseUrl, id: releaseId },
       {
@@ -341,6 +355,7 @@ test("Publish a release without assets on a maintenance branch", async (t) => {
           prerelease: false,
           make_latest: "false",
         },
+        repeat: 1,
       },
     );
 
@@ -357,7 +372,7 @@ test("Publish a release without assets on a maintenance branch", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -367,7 +382,7 @@ test("Publish a release without assets on a maintenance branch", async (t) => {
   t.is(result.id, releaseId);
   t.deepEqual(t.context.log.args[0], ["Verify GitHub authentication"]);
   t.true(t.context.log.calledWith("Published GitHub release: %s", releaseUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release with an array of assets", async (t) => {
@@ -392,15 +407,15 @@ test("Publish a release with an array of assets", async (t) => {
   const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
   const uploadUrl = `${uploadOrigin}${uploadUri}{?name,label}`;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
       clone_url: `https://api.github.local/${owner}/${repo}.git`,
     })
-    .postOnce(
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       { upload_url: uploadUrl, html_url: releaseUrl, id: releaseId },
       {
@@ -414,14 +429,14 @@ test("Publish a release with an array of assets", async (t) => {
         },
       },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       { html_url: releaseUrl },
       {
         body: { draft: false, make_latest: "true" },
       },
     )
-    .postOnce(
+    .post(
       `${uploadOrigin}${uploadUri}?name=${encodeURIComponent(
         "upload_file_name.txt",
       )}&`,
@@ -429,7 +444,7 @@ test("Publish a release with an array of assets", async (t) => {
         browser_download_url: assetUrl,
       },
     )
-    .postOnce(
+    .post(
       `${uploadOrigin}${uploadUri}?name=${encodeURIComponent(
         "other_file.txt",
       )}&label=${encodeURIComponent("Other File")}`,
@@ -449,7 +464,7 @@ test("Publish a release with an array of assets", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -459,7 +474,7 @@ test("Publish a release with an array of assets", async (t) => {
   t.true(t.context.log.calledWith("Published file %s", otherAssetUrl));
   t.true(t.context.log.calledWith("Published file %s", assetUrl));
   t.true(t.context.log.calledWith("Published GitHub release: %s", releaseUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release with release information in assets", async (t) => {
@@ -488,15 +503,15 @@ test("Publish a release with release information in assets", async (t) => {
   const uploadUri = `/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets`;
   const uploadUrl = `${uploadOrigin}${uploadUri}{?name,label}`;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
       clone_url: `https://api.github.local/${owner}/${repo}.git`,
     })
-    .postOnce(
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       { upload_url: uploadUrl, html_url: releaseUrl, id: releaseId },
       {
@@ -510,14 +525,14 @@ test("Publish a release with release information in assets", async (t) => {
         },
       },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       { html_url: releaseUrl },
       {
         body: { draft: false, make_latest: "false" },
       },
     )
-    .postOnce(
+    .post(
       `${uploadOrigin}${uploadUri}?name=${encodeURIComponent(
         "file_with_release_v1.0.0_in_filename.txt",
       )}&label=${encodeURIComponent("File with release v1.0.0 in label")}`,
@@ -537,7 +552,7 @@ test("Publish a release with release information in assets", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -546,7 +561,7 @@ test("Publish a release with release information in assets", async (t) => {
   t.deepEqual(t.context.log.args[0], ["Verify GitHub authentication"]);
   t.true(t.context.log.calledWith("Published file %s", assetUrl));
   t.true(t.context.log.calledWith("Published GitHub release: %s", releaseUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Update a release", async (t) => {
@@ -562,19 +577,19 @@ test("Update a release", async (t) => {
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/${nextRelease.version}`;
   const releaseId = 1;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
       clone_url: `https://api.github.local/${owner}/${repo}.git`,
     })
-    .getOnce(
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       { id: releaseId },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       { html_url: releaseUrl },
       {
@@ -599,7 +614,7 @@ test("Update a release", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -610,7 +625,7 @@ test("Update a release", async (t) => {
     "Updated GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Comment and add labels on PR included in the releases", async (t) => {
@@ -628,8 +643,8 @@ test("Comment and add labels on PR included in the releases", async (t) => {
     { name: "GitHub release", url: "https://github.com/release" },
   ];
 
-  const fetch = fetchMock
-    .sandbox()
+  const fm = fetchMock
+    .createInstance()
     .get(
       `https://api.github.local/repos/${owner}/${repo}`,
       {
@@ -641,12 +656,10 @@ test("Comment and add labels on PR included in the releases", async (t) => {
         repeat: 2,
       },
     )
-    .postOnce(
-      (url, { body }) => {
-        t.is(url, "https://api.github.local/graphql");
-        t.regex(JSON.parse(body).query, /query getAssociatedPRs\(/);
-        return true;
-      },
+    .post(
+      ({ url, options }) =>
+        url === "https://api.github.local/graphql" &&
+        /query getAssociatedPRs\(/.test(JSON.parse(options.body).query),
       {
         data: {
           repository: {
@@ -663,38 +676,30 @@ test("Comment and add labels on PR included in the releases", async (t) => {
           },
         },
       },
+      { repeat: 1 },
     )
-    .getOnce(
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/pulls/1/commits`,
       [{ sha: commits[0].hash }],
+      { repeat: 1 },
     )
-    .postOnce(
-      (url, { body }) => {
-        t.is(
-          url,
-          `https://api.github.local/repos/${owner}/${repo}/issues/1/comments`,
-        );
-
-        const data = JSON.parse(body);
-        t.regex(data.body, /This PR is included/);
-
-        return true;
-      },
+    .post(
+      `https://api.github.local/repos/${owner}/${repo}/issues/1/comments`,
       { html_url: "https://github.com/successcomment-1" },
+      { repeat: 1 },
     )
-    .postOnce(
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/issues/1/labels`,
       {},
       {
         body: ["released"],
+        repeat: 1,
       },
     )
-    .postOnce(
-      (url, { body }) => {
-        t.is(url, "https://api.github.local/graphql");
-        t.regex(JSON.parse(body).query, /query getSRIssues\(/);
-        return true;
-      },
+    .post(
+      ({ url, options }) =>
+        url === "https://api.github.local/graphql" &&
+        /query getSRIssues\(/.test(JSON.parse(options.body).query),
       {
         data: {
           repository: {
@@ -702,6 +707,7 @@ test("Comment and add labels on PR included in the releases", async (t) => {
           },
         },
       },
+      { repeat: 1 },
     );
 
   await t.context.m.success(
@@ -718,7 +724,7 @@ test("Comment and add labels on PR included in the releases", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -734,7 +740,7 @@ test("Comment and add labels on PR included in the releases", async (t) => {
   t.true(
     t.context.log.calledWith("Added labels %O to PR #%d", ["released"], 1),
   );
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Open a new issue with the list of errors", async (t) => {
@@ -749,8 +755,8 @@ test("Open a new issue with the list of errors", async (t) => {
     new SemanticReleaseError("Error message 3", "ERR3", "Error 3 details"),
   ];
 
-  const fetch = fetchMock
-    .sandbox()
+  const fm = fetchMock
+    .createInstance()
     .get(
       `https://api.github.local/repos/${owner}/${repo}`,
       {
@@ -760,17 +766,18 @@ test("Open a new issue with the list of errors", async (t) => {
       },
       { repeat: 2 },
     )
-    .postOnce("https://api.github.local/graphql", {
+    .post("https://api.github.local/graphql", {
       data: {
         repository: {
           issues: { nodes: [] },
         },
       },
     })
-    .postOnce(
-      (url, { body }) => {
-        t.is(url, `https://api.github.local/repos/${owner}/${repo}/issues`);
-        const data = JSON.parse(body);
+    .post(
+      ({ url, options }) => {
+        if (url !== `https://api.github.local/repos/${owner}/${repo}/issues`)
+          return false;
+        const data = JSON.parse(options.body);
         t.is(data.title, failTitle);
         t.regex(
           data.body,
@@ -796,7 +803,7 @@ test("Open a new issue with the list of errors", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -809,7 +816,7 @@ test("Open a new issue with the list of errors", async (t) => {
       "https://github.com/issues/1",
     ),
   );
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Verify, release and notify success", async (t) => {
@@ -843,8 +850,8 @@ test("Verify, release and notify success", async (t) => {
   const prs = [{ number: 1, pull_request: true, state: "closed" }];
   const commits = [{ hash: "123", message: "Commit 1 message" }];
 
-  const fetch = fetchMock
-    .sandbox()
+  const fm = fetchMock
+    .createInstance()
     .get(
       `https://api.github.local/repos/${owner}/${repo}`,
       {
@@ -856,10 +863,10 @@ test("Verify, release and notify success", async (t) => {
         repeat: 2,
       },
     )
-    .postOnce(
-      (url, { body }) =>
+    .post(
+      ({ url, options }) =>
         url === "https://api.github.local/graphql" &&
-        JSON.parse(body).query.includes("query getAssociatedPRs("),
+        JSON.parse(options.body).query.includes("query getAssociatedPRs("),
       {
         data: {
           repository: {
@@ -877,10 +884,10 @@ test("Verify, release and notify success", async (t) => {
         },
       },
     )
-    .postOnce(
-      (url, { body }) =>
+    .post(
+      ({ url, options }) =>
         url === "https://api.github.local/graphql" &&
-        JSON.parse(body).query.includes("query getSRIssues("),
+        JSON.parse(options.body).query.includes("query getSRIssues("),
       {
         data: {
           repository: {
@@ -889,7 +896,7 @@ test("Verify, release and notify success", async (t) => {
         },
       },
     )
-    .postOnce(
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       {
         upload_url: uploadUrl,
@@ -907,25 +914,24 @@ test("Verify, release and notify success", async (t) => {
         },
       },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       { html_url: releaseUrl },
       { body: { draft: false, make_latest: "true" } },
     )
-    .getOnce(
-      `https://api.github.local/repos/${owner}/${repo}/pulls/1/commits`,
-      [{ sha: commits[0].hash }],
-    )
-    .postOnce(
+    .get(`https://api.github.local/repos/${owner}/${repo}/pulls/1/commits`, [
+      { sha: commits[0].hash },
+    ])
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/issues/1/labels`,
       {},
       { body: ["released"] },
     )
-    .postOnce(
+    .post(
       `${uploadOrigin}${uploadUri}?name=${encodeURIComponent("upload.txt")}&`,
       { browser_download_url: assetUrl },
     )
-    .postOnce(
+    .post(
       `${uploadOrigin}${uploadUri}?name=other_file.txt&label=${encodeURIComponent(
         "Other File",
       )}`,
@@ -933,12 +939,9 @@ test("Verify, release and notify success", async (t) => {
         browser_download_url: otherAssetUrl,
       },
     )
-    .postOnce(
-      `https://api.github.local/repos/${owner}/${repo}/issues/1/comments`,
-      {
-        html_url: "https://github.com/successcomment-1",
-      },
-    );
+    .post(`https://api.github.local/repos/${owner}/${repo}/issues/1/comments`, {
+      html_url: "https://github.com/successcomment-1",
+    });
 
   await t.notThrowsAsync(
     t.context.m.verifyConditions(
@@ -947,7 +950,7 @@ test("Verify, release and notify success", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -965,7 +968,7 @@ test("Verify, release and notify success", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -983,7 +986,7 @@ test("Verify, release and notify success", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -992,7 +995,7 @@ test("Verify, release and notify success", async (t) => {
   t.true(t.context.log.calledWith("Published file %s", otherAssetUrl));
   t.true(t.context.log.calledWith("Published file %s", assetUrl));
   t.true(t.context.log.calledWith("Published GitHub release: %s", releaseUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Verify, update release and notify success", async (t) => {
@@ -1019,8 +1022,8 @@ test("Verify, update release and notify success", async (t) => {
     { hash: "123", message: "Commit 1 message", tree: { long: "aaa" } },
   ];
 
-  const fetch = fetchMock
-    .sandbox()
+  const fm = fetchMock
+    .createInstance()
     .get(
       `https://api.github.local/repos/${owner}/${repo}`,
       {
@@ -1032,11 +1035,11 @@ test("Verify, update release and notify success", async (t) => {
         repeat: 2,
       },
     )
-    .getOnce(
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/releases/tags/${nextRelease.gitTag}`,
       { id: releaseId },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       { html_url: releaseUrl },
       {
@@ -1047,12 +1050,10 @@ test("Verify, update release and notify success", async (t) => {
         },
       },
     )
-    .postOnce(
-      (url, { body }) => {
-        t.is(url, "https://api.github.local/graphql");
-        t.regex(JSON.parse(body).query, /query getAssociatedPRs\(/);
-        return true;
-      },
+    .post(
+      ({ url, options }) =>
+        url === "https://api.github.local/graphql" &&
+        /query getAssociatedPRs\(/.test(JSON.parse(options.body).query),
       {
         data: {
           repository: {
@@ -1069,30 +1070,30 @@ test("Verify, update release and notify success", async (t) => {
           },
         },
       },
+      { repeat: 1 },
     )
-    .getOnce(
+    .get(
       `https://api.github.local/repos/${owner}/${repo}/pulls/1/commits`,
       [{ sha: commits[0].hash }],
+      { repeat: 1 },
     )
-    .postOnce(
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/issues/1/comments`,
-      {
-        html_url: "https://github.com/successcomment-1",
-      },
+      { html_url: "https://github.com/successcomment-1" },
+      { repeat: 1 },
     )
-    .postOnce(
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/issues/1/labels`,
       {},
       {
         body: ["released"],
+        repeat: 1,
       },
     )
-    .postOnce(
-      (url, { body }) => {
-        t.is(url, "https://api.github.local/graphql");
-        t.regex(JSON.parse(body).query, /query getSRIssues\(/);
-        return true;
-      },
+    .post(
+      ({ url, options }) =>
+        url === "https://api.github.local/graphql" &&
+        /query getSRIssues\(/.test(JSON.parse(options.body).query),
       {
         data: {
           repository: {
@@ -1100,6 +1101,7 @@ test("Verify, update release and notify success", async (t) => {
           },
         },
       },
+      { repeat: 1 },
     );
 
   await t.notThrowsAsync(
@@ -1109,7 +1111,7 @@ test("Verify, update release and notify success", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1127,7 +1129,7 @@ test("Verify, update release and notify success", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -1145,7 +1147,7 @@ test("Verify, update release and notify success", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -1155,7 +1157,7 @@ test("Verify, update release and notify success", async (t) => {
     "Updated GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Verify and notify failure", async (t) => {
@@ -1170,8 +1172,8 @@ test("Verify and notify failure", async (t) => {
     new SemanticReleaseError("Error message 3", "ERR3", "Error 3 details"),
   ];
 
-  const fetch = fetchMock
-    .sandbox()
+  const fm = fetchMock
+    .createInstance()
     .get(
       `https://api.github.local/repos/${owner}/${repo}`,
       {
@@ -1183,14 +1185,14 @@ test("Verify and notify failure", async (t) => {
         repeat: 2,
       },
     )
-    .postOnce("https://api.github.local/graphql", {
+    .post("https://api.github.local/graphql", {
       data: {
         repository: {
           issues: { nodes: [] },
         },
       },
     })
-    .postOnce(`https://api.github.local/repos/${owner}/${repo}/issues`, {
+    .post(`https://api.github.local/repos/${owner}/${repo}/issues`, {
       html_url: "https://github.com/issues/1",
       number: 1,
     });
@@ -1202,7 +1204,7 @@ test("Verify and notify failure", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1220,7 +1222,7 @@ test("Verify and notify failure", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -1233,5 +1235,5 @@ test("Verify and notify failure", async (t) => {
       "https://github.com/issues/1",
     ),
   );
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -40,7 +40,7 @@ test("Publish a release without creating discussion", async (t) => {
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.local/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -71,7 +71,7 @@ test("Publish a release without creating discussion", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -81,7 +81,7 @@ test("Publish a release without creating discussion", async (t) => {
     "Published GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release and create discussion", async (t) => {
@@ -104,7 +104,7 @@ test("Publish a release and create discussion", async (t) => {
   const discussionId = 1;
   const discussionUrl = `https://github.com/${owner}/${repo}/discussions/${discussionId}`;
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.local/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -137,7 +137,7 @@ test("Publish a release and create discussion", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -151,7 +151,7 @@ test("Publish a release and create discussion", async (t) => {
     "Created GitHub release discussion: %s",
     discussionUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release on a channel", async (t) => {
@@ -171,7 +171,7 @@ test("Publish a release on a channel", async (t) => {
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.local/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -202,7 +202,7 @@ test("Publish a release on a channel", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -212,7 +212,7 @@ test("Publish a release on a channel", async (t) => {
     "Published GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a prerelease without creating discussion", async (t) => {
@@ -232,7 +232,7 @@ test("Publish a prerelease without creating discussion", async (t) => {
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.local/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -263,7 +263,7 @@ test("Publish a prerelease without creating discussion", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -273,7 +273,7 @@ test("Publish a prerelease without creating discussion", async (t) => {
     "Published GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a prerelease and create discussion", async (t) => {
@@ -295,7 +295,7 @@ test("Publish a prerelease and create discussion", async (t) => {
   const discussionId = 1;
   const discussionUrl = `https://github.com/${owner}/${repo}/discussions/${discussionId}`;
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.local/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -328,7 +328,7 @@ test("Publish a prerelease and create discussion", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -342,7 +342,7 @@ test("Publish a prerelease and create discussion", async (t) => {
     "Created GitHub release discussion: %s",
     discussionUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a maintenance release", async (t) => {
@@ -362,7 +362,7 @@ test("Publish a maintenance release", async (t) => {
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.local/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -399,7 +399,7 @@ test("Publish a maintenance release", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -409,7 +409,7 @@ test("Publish a maintenance release", async (t) => {
     "Published GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release with one asset", async (t) => {
@@ -437,9 +437,9 @@ test("Publish a release with one asset", async (t) => {
   const uploadUrl = `${uploadOrigin}${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock
-    .sandbox()
-    .postOnce(
+  const fm = fetchMock
+    .createInstance()
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       {
         upload_url: uploadUrl,
@@ -458,12 +458,12 @@ test("Publish a release with one asset", async (t) => {
         },
       },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       { upload_url: uploadUrl, html_url: releaseUrl },
       { body: { draft: false, make_latest: "true" } },
     )
-    .postOnce(
+    .post(
       `${uploadOrigin}${uploadUri}?name=${encodeURIComponent(
         ".dotfile",
       )}&label=${encodeURIComponent("A dotfile with no ext")}`,
@@ -483,7 +483,7 @@ test("Publish a release with one asset", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -491,7 +491,7 @@ test("Publish a release with one asset", async (t) => {
   t.is(result.url, releaseUrl);
   t.true(t.context.log.calledWith("Published GitHub release: %s", releaseUrl));
   t.true(t.context.log.calledWith("Published file %s", assetUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish upload request does not set content-length manually", async (t) => {
@@ -620,9 +620,9 @@ test("Publish a release with one asset and custom github url", async (t) => {
   const uploadUrl = `${env.GH_URL}${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock
-    .sandbox()
-    .postOnce(
+  const fm = fetchMock
+    .createInstance()
+    .post(
       `${env.GH_URL}/prefix/repos/${owner}/${repo}/releases`,
       {
         upload_url: uploadUrl,
@@ -641,12 +641,12 @@ test("Publish a release with one asset and custom github url", async (t) => {
         },
       },
     )
-    .patchOnce(
+    .patch(
       `${env.GH_URL}/prefix/repos/${owner}/${repo}/releases/${releaseId}`,
       { upload_url: uploadUrl, html_url: releaseUrl },
       { body: { draft: false, make_latest: "true" } },
     )
-    .postOnce(
+    .post(
       `${env.GH_URL}${uploadUri}?name=${encodeURIComponent(
         "upload.txt",
       )}&label=${encodeURIComponent("A text file")}`,
@@ -668,7 +668,7 @@ test("Publish a release with one asset and custom github url", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -676,7 +676,7 @@ test("Publish a release with one asset and custom github url", async (t) => {
   t.is(result.url, releaseUrl);
   t.true(t.context.log.calledWith("Published GitHub release: %s", releaseUrl));
   t.true(t.context.log.calledWith("Published file %s", assetUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release with an array of missing assets", async (t) => {
@@ -702,9 +702,9 @@ test("Publish a release with an array of missing assets", async (t) => {
   const uploadUrl = `${uploadOrigin}${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock
-    .sandbox()
-    .postOnce(
+  const fm = fetchMock
+    .createInstance()
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       {
         upload_url: uploadUrl,
@@ -723,7 +723,7 @@ test("Publish a release with an array of missing assets", async (t) => {
         },
       },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       { html_url: releaseUrl },
       { body: { draft: false, make_latest: "true" } },
@@ -742,7 +742,7 @@ test("Publish a release with an array of missing assets", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -761,7 +761,7 @@ test("Publish a release with an array of missing assets", async (t) => {
       emptyDirectory,
     ),
   );
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release with asset and create discussion", async (t) => {
@@ -792,9 +792,9 @@ test("Publish a release with asset and create discussion", async (t) => {
   const discussionId = 1;
   const discussionUrl = `https://github.com/${owner}/${repo}/discussions/${discussionId}`;
 
-  const fetch = fetchMock
-    .sandbox()
-    .postOnce(
+  const fm = fetchMock
+    .createInstance()
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       {
         upload_url: uploadUrl,
@@ -813,7 +813,7 @@ test("Publish a release with asset and create discussion", async (t) => {
         },
       },
     )
-    .patchOnce(
+    .patch(
       `https://api.github.local/repos/${owner}/${repo}/releases/${releaseId}`,
       {
         upload_url: uploadUrl,
@@ -828,7 +828,7 @@ test("Publish a release with asset and create discussion", async (t) => {
         },
       },
     )
-    .postOnce(
+    .post(
       `${uploadOrigin}${uploadUri}?name=${encodeURIComponent(
         ".dotfile",
       )}&label=${encodeURIComponent("A dotfile with no ext")}`,
@@ -848,7 +848,7 @@ test("Publish a release with asset and create discussion", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -862,7 +862,7 @@ test("Publish a release with asset and create discussion", async (t) => {
     ),
   );
   t.true(t.context.log.calledWith("Published file %s", assetUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a draft release", async (t) => {
@@ -882,7 +882,7 @@ test("Publish a draft release", async (t) => {
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.local/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -914,7 +914,7 @@ test("Publish a draft release", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -924,7 +924,7 @@ test("Publish a draft release", async (t) => {
     "Created GitHub draft release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a draft release with one asset", async (t) => {
@@ -952,9 +952,9 @@ test("Publish a draft release with one asset", async (t) => {
   const uploadUrl = `${uploadOrigin}${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock
-    .sandbox()
-    .postOnce(
+  const fm = fetchMock
+    .createInstance()
+    .post(
       `https://api.github.local/repos/${owner}/${repo}/releases`,
       {
         upload_url: uploadUrl,
@@ -973,7 +973,7 @@ test("Publish a draft release with one asset", async (t) => {
         },
       },
     )
-    .postOnce(
+    .post(
       `${uploadOrigin}${uploadUri}?name=${encodeURIComponent(
         ".dotfile",
       )}&label=${encodeURIComponent("A dotfile with no ext")}`,
@@ -993,7 +993,7 @@ test("Publish a draft release with one asset", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -1003,7 +1003,7 @@ test("Publish a draft release with one asset", async (t) => {
     t.context.log.calledWith("Created GitHub draft release: %s", releaseUrl),
   );
   t.true(t.context.log.calledWith("Published file %s", assetUrl));
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a release when env.GITHUB_URL is set to https://github.com (Default in GitHub Actions, #268)", async (t) => {
@@ -1029,7 +1029,7 @@ test("Publish a release when env.GITHUB_URL is set to https://github.com (Defaul
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.com/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -1060,7 +1060,7 @@ test("Publish a release when env.GITHUB_URL is set to https://github.com (Defaul
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -1070,7 +1070,7 @@ test("Publish a release when env.GITHUB_URL is set to https://github.com (Defaul
     "Published GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a custom release body", async (t) => {
@@ -1093,7 +1093,7 @@ test("Publish a custom release body", async (t) => {
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.local/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -1124,7 +1124,7 @@ test("Publish a custom release body", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -1134,7 +1134,7 @@ test("Publish a custom release body", async (t) => {
     "Published GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Publish a custom release name", async (t) => {
@@ -1157,7 +1157,7 @@ test("Publish a custom release name", async (t) => {
   const uploadUrl = `https://github.com${uploadUri}{?name,label}`;
   const branch = "test_branch";
 
-  const fetch = fetchMock.sandbox().postOnce(
+  const fm = fetchMock.createInstance().post(
     `https://api.github.local/repos/${owner}/${repo}/releases`,
     {
       upload_url: uploadUrl,
@@ -1188,7 +1188,7 @@ test("Publish a custom release name", async (t) => {
     {
       Octokit: TestOctokit.defaults((options) => ({
         ...options,
-        request: { ...options.request, fetch },
+        request: { ...options.request, fetch: fm.fetchHandler },
       })),
     },
   );
@@ -1198,5 +1198,5 @@ test("Publish a custom release name", async (t) => {
     "Published GitHub release: %s",
     releaseUrl,
   ]);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -32,9 +32,9 @@ test("Verify package, token and repository access", async (t) => {
   const labels = ["semantic-release"];
   const discussionCategoryName = "Announcements";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -62,12 +62,12 @@ test("Verify package, token and repository access", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify package, token and repository access with "proxy", "asset", "discussionCategoryName", "successComment", "failTitle", "failComment" and "label" set to "null"', async (t) => {
@@ -82,9 +82,9 @@ test('Verify package, token and repository access with "proxy", "asset", "discus
   const labels = null;
   const discussionCategoryName = null;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -112,12 +112,12 @@ test('Verify package, token and repository access with "proxy", "asset", "discus
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Verify package, token and repository access and custom URL with prefix", async (t) => {
@@ -127,9 +127,9 @@ test("Verify package, token and repository access and custom URL with prefix", a
   const githubUrl = "https://othertesturl.com:9090";
   const githubApiPathPrefix = "prefix";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://othertesturl.com:9090/prefix/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://othertesturl.com:9090/prefix/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -149,13 +149,13 @@ test("Verify package, token and repository access and custom URL with prefix", a
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
   t.deepEqual(t.context.log.args[0], [
     "Verify GitHub authentication (%s)",
     "https://othertesturl.com:9090/prefix",
@@ -168,9 +168,9 @@ test("Verify package, token and repository access and custom URL without prefix"
   const env = { GH_TOKEN: "github_token" };
   const githubUrl = "https://othertesturl.com:9090";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://othertesturl.com:9090/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://othertesturl.com:9090/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -190,13 +190,13 @@ test("Verify package, token and repository access and custom URL without prefix"
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
   t.deepEqual(t.context.log.args[0], [
     "Verify GitHub authentication (%s)",
     "https://othertesturl.com:9090",
@@ -209,9 +209,9 @@ test("Verify package, token and repository access and shorthand repositoryUrl UR
   const env = { GH_TOKEN: "github_token" };
   const githubUrl = "https://othertesturl.com:9090";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://othertesturl.com:9090/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://othertesturl.com:9090/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -229,13 +229,13 @@ test("Verify package, token and repository access and shorthand repositoryUrl UR
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
   t.deepEqual(t.context.log.args[0], [
     "Verify GitHub authentication (%s)",
     "https://othertesturl.com:9090",
@@ -251,9 +251,9 @@ test("Verify package, token and repository with environment variables", async (t
     GH_PREFIX: "prefix",
     HTTP_PROXY: "https://localhost",
   };
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://othertesturl.com:443/prefix/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://othertesturl.com:443/prefix/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -273,13 +273,13 @@ test("Verify package, token and repository with environment variables", async (t
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
   t.deepEqual(t.context.log.args[0], [
     "Verify GitHub authentication (%s)",
     "https://othertesturl.com:443/prefix",
@@ -295,9 +295,9 @@ test("Verify package, token and repository access with alternative environment v
     GITHUB_PREFIX: "prefix",
   };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://othertesturl.com:443/prefix/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://othertesturl.com:443/prefix/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -317,12 +317,12 @@ test("Verify package, token and repository access with alternative environment v
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Verify package, token and repository access with custom API URL", async (t) => {
@@ -332,9 +332,9 @@ test("Verify package, token and repository access with custom API URL", async (t
   const githubUrl = "https://othertesturl.com:9090";
   const githubApiUrl = "https://api.othertesturl.com:9090";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.othertesturl.com:9090/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.othertesturl.com:9090/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -352,13 +352,13 @@ test("Verify package, token and repository access with custom API URL", async (t
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
   t.deepEqual(t.context.log.args[0], [
     "Verify GitHub authentication (%s)",
     "https://api.othertesturl.com:9090",
@@ -374,9 +374,9 @@ test("Verify package, token and repository access with API URL in environment va
     GITHUB_TOKEN: "github_token",
   };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.othertesturl.com:443/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.othertesturl.com:443/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -396,12 +396,12 @@ test("Verify package, token and repository access with API URL in environment va
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "proxy" is a String', async (t) => {
@@ -410,9 +410,9 @@ test('Verify "proxy" is a String', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const proxy = "https://locahost";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -430,13 +430,13 @@ test('Verify "proxy" is a String', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "proxy" is an object with "host" and "port" properties', async (t) => {
@@ -445,9 +445,9 @@ test('Verify "proxy" is an object with "host" and "port" properties', async (t) 
   const env = { GH_TOKEN: "github_token" };
   const proxy = { host: "locahost", port: 80 };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -467,13 +467,13 @@ test('Verify "proxy" is an object with "host" and "port" properties', async (t) 
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "proxy" is a Boolean set to false', async (t) => {
@@ -482,9 +482,9 @@ test('Verify "proxy" is a Boolean set to false', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const proxy = false;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -502,13 +502,13 @@ test('Verify "proxy" is a Boolean set to false', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "assets" is a String', async (t) => {
@@ -517,9 +517,9 @@ test('Verify "assets" is a String', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const assets = "file2.js";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -537,13 +537,13 @@ test('Verify "assets" is a String', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "assets" is an Object with a path property', async (t) => {
@@ -552,9 +552,9 @@ test('Verify "assets" is an Object with a path property', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const assets = { path: "file2.js" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -572,13 +572,13 @@ test('Verify "assets" is an Object with a path property', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "assets" is an Array of Object with a path property', async (t) => {
@@ -587,9 +587,9 @@ test('Verify "assets" is an Array of Object with a path property', async (t) => 
   const env = { GH_TOKEN: "github_token" };
   const assets = [{ path: "file1.js" }, { path: "file2.js" }];
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -609,13 +609,13 @@ test('Verify "assets" is an Array of Object with a path property', async (t) => 
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "assets" is an Array of glob Arrays', async (t) => {
@@ -624,9 +624,9 @@ test('Verify "assets" is an Array of glob Arrays', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const assets = [["dist/**", "!**/*.js"], "file2.js"];
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -644,13 +644,13 @@ test('Verify "assets" is an Array of glob Arrays', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "assets" is an Array of Object with a glob Arrays in path property', async (t) => {
@@ -659,9 +659,9 @@ test('Verify "assets" is an Array of Object with a glob Arrays in path property'
   const env = { GH_TOKEN: "github_token" };
   const assets = [{ path: ["dist/**", "!**/*.js"] }, { path: "file2.js" }];
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -681,13 +681,13 @@ test('Verify "assets" is an Array of Object with a glob Arrays in path property'
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "labels" is a String', async (t) => {
@@ -696,9 +696,9 @@ test('Verify "labels" is a String', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const labels = "semantic-release";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -716,13 +716,13 @@ test('Verify "labels" is a String', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "assignees" is a String', async (t) => {
@@ -731,9 +731,9 @@ test('Verify "assignees" is a String', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const assignees = "user";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -751,13 +751,13 @@ test('Verify "assignees" is a String', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "addReleases" is a valid string (top)', async (t) => {
@@ -766,9 +766,9 @@ test('Verify "addReleases" is a valid string (top)', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const addReleases = "top";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -786,13 +786,13 @@ test('Verify "addReleases" is a valid string (top)', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "addReleases" is a valid string (bottom)', async (t) => {
@@ -801,9 +801,9 @@ test('Verify "addReleases" is a valid string (bottom)', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const addReleases = "bottom";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -821,13 +821,13 @@ test('Verify "addReleases" is a valid string (bottom)', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "addReleases" is valid (false)', async (t) => {
@@ -836,9 +836,9 @@ test('Verify "addReleases" is valid (false)', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const addReleases = false;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -856,13 +856,13 @@ test('Verify "addReleases" is valid (false)', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "draftRelease" is valid (true)', async (t) => {
@@ -871,9 +871,9 @@ test('Verify "draftRelease" is valid (true)', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const draftRelease = true;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -891,13 +891,13 @@ test('Verify "draftRelease" is valid (true)', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Verify "draftRelease" is valid (false)', async (t) => {
@@ -906,9 +906,9 @@ test('Verify "draftRelease" is valid (false)', async (t) => {
   const env = { GH_TOKEN: "github_token" };
   const draftRelease = false;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -926,13 +926,13 @@ test('Verify "draftRelease" is valid (false)', async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 // https://github.com/semantic-release/github/issues/182
@@ -951,9 +951,9 @@ test("Verify if run in GitHub Action", async (t) => {
   const labels = ["semantic-release"];
   const discussionCategoryName = "Announcements";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       clone_url: `https://api.github.local/${owner}/${repo}.git`,
     });
 
@@ -970,13 +970,13 @@ test("Verify if run in GitHub Action", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 // https://github.com/semantic-release/github/issues/182
@@ -995,9 +995,9 @@ test("Verify if run in GitHub Action and repo is renamed", async (t) => {
   const labels = ["semantic-release"];
   const discussionCategoryName = "Announcements";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       clone_url: `https://api.github.local/${owner}/${repo}2.git`,
     });
 
@@ -1016,7 +1016,7 @@ test("Verify if run in GitHub Action and repo is renamed", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1025,7 +1025,7 @@ test("Verify if run in GitHub Action and repo is renamed", async (t) => {
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EMISMATCHGITHUBURL");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Verify if token is a Github installation token and repo is renamed", async (t) => {
@@ -1033,18 +1033,15 @@ test("Verify if token is a Github installation token and repo is renamed", async
   const repo = "test_repo";
   const env = { GH_TOKEN: "github_token" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: false,
       },
       clone_url: `https://api.github.local/${owner}/${repo}2.git`,
     })
-    .headOnce(
-      "https://api.github.local/installation/repositories?per_page=1",
-      200,
-    );
+    .head("https://api.github.local/installation/repositories?per_page=1", 200);
 
   const {
     errors: [error, ...errors],
@@ -1059,7 +1056,7 @@ test("Verify if token is a Github installation token and repo is renamed", async
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1068,7 +1065,7 @@ test("Verify if token is a Github installation token and repo is renamed", async
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EMISMATCHGITHUBURL");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Throw SemanticReleaseError for missing github token", async (t) => {
@@ -1087,7 +1084,7 @@ test("Throw SemanticReleaseError for missing github token", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1103,9 +1100,9 @@ test("Throw SemanticReleaseError for invalid token", async (t) => {
   const repo = "test_repo";
   const env = { GH_TOKEN: "github_token" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, 401);
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, 401);
 
   const {
     errors: [error, ...errors],
@@ -1120,7 +1117,7 @@ test("Throw SemanticReleaseError for invalid token", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1129,7 +1126,7 @@ test("Throw SemanticReleaseError for invalid token", async (t) => {
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDGHTOKEN");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Throw SemanticReleaseError for invalid repositoryUrl", async (t) => {
@@ -1148,7 +1145,7 @@ test("Throw SemanticReleaseError for invalid repositoryUrl", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1164,18 +1161,15 @@ test("Throw SemanticReleaseError if token doesn't have the push permission on th
   const repo = "test_repo";
   const env = { GH_TOKEN: "github_token" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: false,
       },
       clone_url: `https://api.github.local/${owner}/${repo}.git`,
     })
-    .headOnce(
-      "https://api.github.local/installation/repositories?per_page=1",
-      403,
-    );
+    .head("https://api.github.local/installation/repositories?per_page=1", 403);
 
   const {
     errors: [error, ...errors],
@@ -1190,7 +1184,7 @@ test("Throw SemanticReleaseError if token doesn't have the push permission on th
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1199,7 +1193,7 @@ test("Throw SemanticReleaseError if token doesn't have the push permission on th
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EGHNOPERMISSION");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Do not throw SemanticReleaseError if token doesn't have the push permission but it is a Github installation token", async (t) => {
@@ -1207,18 +1201,15 @@ test("Do not throw SemanticReleaseError if token doesn't have the push permissio
   const repo = "test_repo";
   const env = { GH_TOKEN: "github_token" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: false,
       },
       clone_url: `https://api.github.local/${owner}/${repo}.git`,
     })
-    .headOnce(
-      "https://api.github.local/installation/repositories?per_page=1",
-      200,
-    );
+    .head("https://api.github.local/installation/repositories?per_page=1", 200);
 
   await t.notThrowsAsync(
     verify(
@@ -1231,13 +1222,13 @@ test("Do not throw SemanticReleaseError if token doesn't have the push permissio
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test("Throw SemanticReleaseError if the repository doesn't exist", async (t) => {
@@ -1245,9 +1236,9 @@ test("Throw SemanticReleaseError if the repository doesn't exist", async (t) => 
   const repo = "test_repo";
   const env = { GH_TOKEN: "github_token" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, 404);
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, 404);
 
   const {
     errors: [error, ...errors],
@@ -1262,7 +1253,7 @@ test("Throw SemanticReleaseError if the repository doesn't exist", async (t) => 
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1271,19 +1262,19 @@ test("Throw SemanticReleaseError if the repository doesn't exist", async (t) => 
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EMISSINGREPO");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test(`Don't throw an error if owner/repo only differs in case`, async (t) => {
   const env = { GH_TOKEN: "github_token" };
 
-  const fetch = fetchMock.sandbox().getOnce(
+  const fm = fetchMock.createInstance().get(
     `https://api.github.local/repos/org/foo`,
     {
       permissions: { push: true },
       clone_url: `https://github.com/ORG/FOO.git`,
     },
-    { repeat: 2 },
+    { repeat: 1 },
   );
 
   await t.notThrowsAsync(
@@ -1299,13 +1290,13 @@ test(`Don't throw an error if owner/repo only differs in case`, async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 const urlFormats = [
@@ -1324,13 +1315,13 @@ for (const makeRepositoryUrl of urlFormats) {
     test(`Don't throw an error if clone_url differs from repositoryUrl but owner/repo is the same -- ${makeRepositoryUrl(owner, repo)} / ${make_clone_url(owner, repo)}`, async (t) => {
       const env = { GH_TOKEN: "github_token" };
 
-      const fetch = fetchMock.sandbox().getOnce(
+      const fm = fetchMock.createInstance().get(
         `https://api.github.local/repos/${owner}/${repo}`,
         {
           permissions: { push: true },
           clone_url: make_clone_url(owner, repo),
         },
-        { repeat: 2 },
+        { repeat: 1 },
       );
 
       await t.notThrowsAsync(
@@ -1346,26 +1337,26 @@ for (const makeRepositoryUrl of urlFormats) {
           {
             Octokit: TestOctokit.defaults((options) => ({
               ...options,
-              request: { ...options.request, fetch },
+              request: { ...options.request, fetch: fm.fetchHandler },
             })),
           },
         ),
       );
 
-      t.true(fetch.done());
+      t.true(fm.callHistory.done());
     });
 
     const repo2 = repo + "2";
     test(`Throw SemanticReleaseError if the repository is renamed -- ${makeRepositoryUrl(owner, repo)} / ${make_clone_url(owner, repo2)}`, async (t) => {
       const env = { GH_TOKEN: "github_token" };
 
-      const fetch = fetchMock.sandbox().getOnce(
+      const fm = fetchMock.createInstance().get(
         `https://api.github.local/repos/${owner}/${repo}`,
         {
           permissions: { push: true },
           clone_url: make_clone_url(owner, repo2),
         },
-        { repeat: 2 },
+        { repeat: 1 },
       );
 
       const {
@@ -1381,7 +1372,7 @@ for (const makeRepositoryUrl of urlFormats) {
           {
             Octokit: TestOctokit.defaults((options) => ({
               ...options,
-              request: { ...options.request, fetch },
+              request: { ...options.request, fetch: fm.fetchHandler },
             })),
           },
         ),
@@ -1390,7 +1381,7 @@ for (const makeRepositoryUrl of urlFormats) {
       t.is(errors.length, 0);
       t.is(error.name, "SemanticReleaseError");
       t.is(error.code, "EMISMATCHGITHUBURL");
-      t.true(fetch.done());
+      t.true(fm.callHistory.done());
     });
   }
 }
@@ -1400,9 +1391,9 @@ test("Throw error if github return any other errors", async (t) => {
   const repo = "test_repo";
   const env = { GH_TOKEN: "github_token" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, 500);
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, 500);
 
   const error = await t.throwsAsync(
     verify(
@@ -1415,14 +1406,14 @@ test("Throw error if github return any other errors", async (t) => {
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
   );
 
   t.is(error.status, 500);
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "proxy" option is not a String or an Object', async (t) => {
@@ -1444,7 +1435,7 @@ test('Throw SemanticReleaseError if "proxy" option is not a String or an Object'
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1474,7 +1465,7 @@ test('Throw SemanticReleaseError if "proxy" option is an Object with invalid pro
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1491,9 +1482,9 @@ test('Throw SemanticReleaseError if "assets" option is not a String or an Array 
   const env = { GH_TOKEN: "github_token" };
   const assets = 42;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1513,7 +1504,7 @@ test('Throw SemanticReleaseError if "assets" option is not a String or an Array 
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1522,7 +1513,7 @@ test('Throw SemanticReleaseError if "assets" option is not a String or an Array 
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDASSETS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "assets" option is an Array with invalid elements', async (t) => {
@@ -1531,9 +1522,9 @@ test('Throw SemanticReleaseError if "assets" option is an Array with invalid ele
   const env = { GH_TOKEN: "github_token" };
   const assets = ["file.js", 42];
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1553,7 +1544,7 @@ test('Throw SemanticReleaseError if "assets" option is an Array with invalid ele
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1562,7 +1553,7 @@ test('Throw SemanticReleaseError if "assets" option is an Array with invalid ele
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDASSETS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "assets" option is an Object missing the "path" property', async (t) => {
@@ -1571,9 +1562,9 @@ test('Throw SemanticReleaseError if "assets" option is an Object missing the "pa
   const env = { GH_TOKEN: "github_token" };
   const assets = { name: "file.js" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1593,7 +1584,7 @@ test('Throw SemanticReleaseError if "assets" option is an Object missing the "pa
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1602,7 +1593,7 @@ test('Throw SemanticReleaseError if "assets" option is an Object missing the "pa
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDASSETS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "assets" option is an Array with objects missing the "path" property', async (t) => {
@@ -1611,9 +1602,9 @@ test('Throw SemanticReleaseError if "assets" option is an Array with objects mis
   const env = { GH_TOKEN: "github_token" };
   const assets = [{ path: "lib/file.js" }, { name: "file.js" }];
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1633,7 +1624,7 @@ test('Throw SemanticReleaseError if "assets" option is an Array with objects mis
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1642,7 +1633,7 @@ test('Throw SemanticReleaseError if "assets" option is an Array with objects mis
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDASSETS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "successComment" option is not a String', async (t) => {
@@ -1651,9 +1642,9 @@ test('Throw SemanticReleaseError if "successComment" option is not a String', as
   const env = { GH_TOKEN: "github_token" };
   const successComment = 42;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1673,7 +1664,7 @@ test('Throw SemanticReleaseError if "successComment" option is not a String', as
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1682,7 +1673,7 @@ test('Throw SemanticReleaseError if "successComment" option is not a String', as
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDSUCCESSCOMMENT");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "successComment" option is an empty String', async (t) => {
@@ -1691,9 +1682,9 @@ test('Throw SemanticReleaseError if "successComment" option is an empty String',
   const env = { GH_TOKEN: "github_token" };
   const successComment = "";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1713,7 +1704,7 @@ test('Throw SemanticReleaseError if "successComment" option is an empty String',
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1722,7 +1713,7 @@ test('Throw SemanticReleaseError if "successComment" option is an empty String',
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDSUCCESSCOMMENT");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "successComment" option is a whitespace String', async (t) => {
@@ -1731,9 +1722,9 @@ test('Throw SemanticReleaseError if "successComment" option is a whitespace Stri
   const env = { GH_TOKEN: "github_token" };
   const successComment = "  \n \r ";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1753,7 +1744,7 @@ test('Throw SemanticReleaseError if "successComment" option is a whitespace Stri
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1762,7 +1753,7 @@ test('Throw SemanticReleaseError if "successComment" option is a whitespace Stri
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDSUCCESSCOMMENT");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "failTitle" option is not a String', async (t) => {
@@ -1771,9 +1762,9 @@ test('Throw SemanticReleaseError if "failTitle" option is not a String', async (
   const env = { GH_TOKEN: "github_token" };
   const failTitle = 42;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1793,7 +1784,7 @@ test('Throw SemanticReleaseError if "failTitle" option is not a String', async (
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1802,7 +1793,7 @@ test('Throw SemanticReleaseError if "failTitle" option is not a String', async (
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDFAILTITLE");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "failTitle" option is an empty String', async (t) => {
@@ -1811,9 +1802,9 @@ test('Throw SemanticReleaseError if "failTitle" option is an empty String', asyn
   const env = { GH_TOKEN: "github_token" };
   const failTitle = "";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1833,7 +1824,7 @@ test('Throw SemanticReleaseError if "failTitle" option is an empty String', asyn
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1842,7 +1833,7 @@ test('Throw SemanticReleaseError if "failTitle" option is an empty String', asyn
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDFAILTITLE");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "failTitle" option is a whitespace String', async (t) => {
@@ -1851,9 +1842,9 @@ test('Throw SemanticReleaseError if "failTitle" option is a whitespace String', 
   const env = { GH_TOKEN: "github_token" };
   const failTitle = "  \n \r ";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1873,7 +1864,7 @@ test('Throw SemanticReleaseError if "failTitle" option is a whitespace String', 
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1882,7 +1873,7 @@ test('Throw SemanticReleaseError if "failTitle" option is a whitespace String', 
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDFAILTITLE");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "discussionCategoryName" option is not a String', async (t) => {
@@ -1891,9 +1882,9 @@ test('Throw SemanticReleaseError if "discussionCategoryName" option is not a Str
   const env = { GH_TOKEN: "github_token" };
   const discussionCategoryName = 42;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1913,7 +1904,7 @@ test('Throw SemanticReleaseError if "discussionCategoryName" option is not a Str
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1922,7 +1913,7 @@ test('Throw SemanticReleaseError if "discussionCategoryName" option is not a Str
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDDISCUSSIONCATEGORYNAME");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "discussionCategoryName" option is an empty String', async (t) => {
@@ -1931,9 +1922,9 @@ test('Throw SemanticReleaseError if "discussionCategoryName" option is an empty 
   const env = { GH_TOKEN: "github_token" };
   const discussionCategoryName = "";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1953,7 +1944,7 @@ test('Throw SemanticReleaseError if "discussionCategoryName" option is an empty 
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -1962,7 +1953,7 @@ test('Throw SemanticReleaseError if "discussionCategoryName" option is an empty 
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDDISCUSSIONCATEGORYNAME");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "discussionCategoryName" option is a whitespace String', async (t) => {
@@ -1971,9 +1962,9 @@ test('Throw SemanticReleaseError if "discussionCategoryName" option is a whitesp
   const env = { GH_TOKEN: "github_token" };
   const discussionCategoryName = "  \n \r ";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -1993,7 +1984,7 @@ test('Throw SemanticReleaseError if "discussionCategoryName" option is a whitesp
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2002,7 +1993,7 @@ test('Throw SemanticReleaseError if "discussionCategoryName" option is a whitesp
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDDISCUSSIONCATEGORYNAME");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "failComment" option is not a String', async (t) => {
@@ -2011,9 +2002,9 @@ test('Throw SemanticReleaseError if "failComment" option is not a String', async
   const env = { GH_TOKEN: "github_token" };
   const failComment = 42;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2033,7 +2024,7 @@ test('Throw SemanticReleaseError if "failComment" option is not a String', async
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2042,7 +2033,7 @@ test('Throw SemanticReleaseError if "failComment" option is not a String', async
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDFAILCOMMENT");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "failComment" option is an empty String', async (t) => {
@@ -2051,9 +2042,9 @@ test('Throw SemanticReleaseError if "failComment" option is an empty String', as
   const env = { GH_TOKEN: "github_token" };
   const failComment = "";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2073,7 +2064,7 @@ test('Throw SemanticReleaseError if "failComment" option is an empty String', as
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2082,7 +2073,7 @@ test('Throw SemanticReleaseError if "failComment" option is an empty String', as
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDFAILCOMMENT");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "failComment" option is a whitespace String', async (t) => {
@@ -2091,9 +2082,9 @@ test('Throw SemanticReleaseError if "failComment" option is a whitespace String'
   const env = { GH_TOKEN: "github_token" };
   const failComment = "  \n \r ";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2113,7 +2104,7 @@ test('Throw SemanticReleaseError if "failComment" option is a whitespace String'
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2122,7 +2113,7 @@ test('Throw SemanticReleaseError if "failComment" option is a whitespace String'
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDFAILCOMMENT");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "labels" option is not a String or an Array of String', async (t) => {
@@ -2131,9 +2122,9 @@ test('Throw SemanticReleaseError if "labels" option is not a String or an Array 
   const env = { GH_TOKEN: "github_token" };
   const labels = 42;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2153,7 +2144,7 @@ test('Throw SemanticReleaseError if "labels" option is not a String or an Array 
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2162,7 +2153,7 @@ test('Throw SemanticReleaseError if "labels" option is not a String or an Array 
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDLABELS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "labels" option is an Array with invalid elements', async (t) => {
@@ -2171,9 +2162,9 @@ test('Throw SemanticReleaseError if "labels" option is an Array with invalid ele
   const env = { GH_TOKEN: "github_token" };
   const labels = ["label1", 42];
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2193,7 +2184,7 @@ test('Throw SemanticReleaseError if "labels" option is an Array with invalid ele
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2202,7 +2193,7 @@ test('Throw SemanticReleaseError if "labels" option is an Array with invalid ele
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDLABELS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "labels" option is a whitespace String', async (t) => {
@@ -2211,9 +2202,9 @@ test('Throw SemanticReleaseError if "labels" option is a whitespace String', asy
   const env = { GH_TOKEN: "github_token" };
   const labels = "  \n \r ";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2233,7 +2224,7 @@ test('Throw SemanticReleaseError if "labels" option is a whitespace String', asy
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2242,7 +2233,7 @@ test('Throw SemanticReleaseError if "labels" option is a whitespace String', asy
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDLABELS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "assignees" option is not a String or an Array of String', async (t) => {
@@ -2251,9 +2242,9 @@ test('Throw SemanticReleaseError if "assignees" option is not a String or an Arr
   const env = { GH_TOKEN: "github_token" };
   const assignees = 42;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2273,7 +2264,7 @@ test('Throw SemanticReleaseError if "assignees" option is not a String or an Arr
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2282,7 +2273,7 @@ test('Throw SemanticReleaseError if "assignees" option is not a String or an Arr
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDASSIGNEES");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "assignees" option is an Array with invalid elements', async (t) => {
@@ -2291,9 +2282,9 @@ test('Throw SemanticReleaseError if "assignees" option is an Array with invalid 
   const env = { GH_TOKEN: "github_token" };
   const assignees = ["user", 42];
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2313,7 +2304,7 @@ test('Throw SemanticReleaseError if "assignees" option is an Array with invalid 
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2322,7 +2313,7 @@ test('Throw SemanticReleaseError if "assignees" option is an Array with invalid 
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDASSIGNEES");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "assignees" option is a whitespace String', async (t) => {
@@ -2331,9 +2322,9 @@ test('Throw SemanticReleaseError if "assignees" option is a whitespace String', 
   const env = { GH_TOKEN: "github_token" };
   const assignees = "  \n \r ";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2353,7 +2344,7 @@ test('Throw SemanticReleaseError if "assignees" option is a whitespace String', 
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2362,7 +2353,7 @@ test('Throw SemanticReleaseError if "assignees" option is a whitespace String', 
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDASSIGNEES");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "releasedLabels" option is not a String or an Array of String', async (t) => {
@@ -2371,9 +2362,9 @@ test('Throw SemanticReleaseError if "releasedLabels" option is not a String or a
   const env = { GH_TOKEN: "github_token" };
   const releasedLabels = 42;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2393,7 +2384,7 @@ test('Throw SemanticReleaseError if "releasedLabels" option is not a String or a
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2402,7 +2393,7 @@ test('Throw SemanticReleaseError if "releasedLabels" option is not a String or a
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDRELEASEDLABELS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "releasedLabels" option is an Array with invalid elements', async (t) => {
@@ -2411,9 +2402,9 @@ test('Throw SemanticReleaseError if "releasedLabels" option is an Array with inv
   const env = { GH_TOKEN: "github_token" };
   const releasedLabels = ["label1", 42];
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2433,7 +2424,7 @@ test('Throw SemanticReleaseError if "releasedLabels" option is an Array with inv
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2442,7 +2433,7 @@ test('Throw SemanticReleaseError if "releasedLabels" option is an Array with inv
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDRELEASEDLABELS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "releasedLabels" option is a whitespace String', async (t) => {
@@ -2451,9 +2442,9 @@ test('Throw SemanticReleaseError if "releasedLabels" option is a whitespace Stri
   const env = { GH_TOKEN: "github_token" };
   const releasedLabels = "  \n \r ";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2473,7 +2464,7 @@ test('Throw SemanticReleaseError if "releasedLabels" option is a whitespace Stri
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2482,7 +2473,7 @@ test('Throw SemanticReleaseError if "releasedLabels" option is a whitespace Stri
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDRELEASEDLABELS");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "addReleases" option is not a valid string (botom)', async (t) => {
@@ -2491,9 +2482,9 @@ test('Throw SemanticReleaseError if "addReleases" option is not a valid string (
   const env = { GH_TOKEN: "github_token" };
   const addReleases = "botom";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2513,7 +2504,7 @@ test('Throw SemanticReleaseError if "addReleases" option is not a valid string (
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2522,7 +2513,7 @@ test('Throw SemanticReleaseError if "addReleases" option is not a valid string (
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDADDRELEASES");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "addReleases" option is not a valid string (true)', async (t) => {
@@ -2531,9 +2522,9 @@ test('Throw SemanticReleaseError if "addReleases" option is not a valid string (
   const env = { GH_TOKEN: "github_token" };
   const addReleases = true;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2553,7 +2544,7 @@ test('Throw SemanticReleaseError if "addReleases" option is not a valid string (
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2562,7 +2553,7 @@ test('Throw SemanticReleaseError if "addReleases" option is not a valid string (
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDADDRELEASES");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "addReleases" option is not a valid string (number)', async (t) => {
@@ -2571,9 +2562,9 @@ test('Throw SemanticReleaseError if "addReleases" option is not a valid string (
   const env = { GH_TOKEN: "github_token" };
   const addReleases = 42;
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2593,7 +2584,7 @@ test('Throw SemanticReleaseError if "addReleases" option is not a valid string (
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2602,7 +2593,7 @@ test('Throw SemanticReleaseError if "addReleases" option is not a valid string (
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDADDRELEASES");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "draftRelease" option is not a valid boolean (string)', async (t) => {
@@ -2611,9 +2602,9 @@ test('Throw SemanticReleaseError if "draftRelease" option is not a valid boolean
   const env = { GH_TOKEN: "github_token" };
   const draftRelease = "test";
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2633,7 +2624,7 @@ test('Throw SemanticReleaseError if "draftRelease" option is not a valid boolean
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2642,7 +2633,7 @@ test('Throw SemanticReleaseError if "draftRelease" option is not a valid boolean
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDDRAFTRELEASE");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "releaseBodyTemplate" option is an empty string', async (t) => {
@@ -2650,9 +2641,9 @@ test('Throw SemanticReleaseError if "releaseBodyTemplate" option is an empty str
   const repo = "test_repo";
   const env = { GH_TOKEN: "github_token" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2672,7 +2663,7 @@ test('Throw SemanticReleaseError if "releaseBodyTemplate" option is an empty str
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2681,7 +2672,7 @@ test('Throw SemanticReleaseError if "releaseBodyTemplate" option is an empty str
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDRELEASEBODYTEMPLATE");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });
 
 test('Throw SemanticReleaseError if "releaseNameTemplate" option is an empty string', async (t) => {
@@ -2689,9 +2680,9 @@ test('Throw SemanticReleaseError if "releaseNameTemplate" option is an empty str
   const repo = "test_repo";
   const env = { GH_TOKEN: "github_token" };
 
-  const fetch = fetchMock
-    .sandbox()
-    .getOnce(`https://api.github.local/repos/${owner}/${repo}`, {
+  const fm = fetchMock
+    .createInstance()
+    .get(`https://api.github.local/repos/${owner}/${repo}`, {
       permissions: {
         push: true,
       },
@@ -2711,7 +2702,7 @@ test('Throw SemanticReleaseError if "releaseNameTemplate" option is an empty str
       {
         Octokit: TestOctokit.defaults((options) => ({
           ...options,
-          request: { ...options.request, fetch },
+          request: { ...options.request, fetch: fm.fetchHandler },
         })),
       },
     ),
@@ -2720,5 +2711,5 @@ test('Throw SemanticReleaseError if "releaseNameTemplate" option is an empty str
   t.is(errors.length, 0);
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "EINVALIDRELEASENAMETEMPLATE");
-  t.true(fetch.done());
+  t.true(fm.callHistory.done());
 });


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/LuisUrrutia'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/LuisUrrutia/tally.svg'></a>

## Summary

- Replace the forked `@gr2m/fetch-mock@9.11.0` package with the official `fetch-mock@12.6.0` release.
- Migrate the test suite to the v12 API while preserving the release behavior now covered on `master`, including `make_latest`.

## Changes

- Replace `sandbox()` with `createInstance()` and pass `fetchHandler` to Octokit.
- Replace `*Once()` routes with `{ repeat: 1 }` and check completion through `callHistory.done()`.
- Update function matchers to accept `{ url, options }` and return `false` when a route should fall through.

## Test plan

- [x] `npx ava --verbose test/integration.test.js test/publish.test.js` (31 tests passed)
- [x] `npm test` (format, lockfile, engines, publint, 265 unit tests, and 15 integration tests passed)
- [x] `node -e 'await import("./index.js")'`
