### PR TITLE
chore: remove npm 'next version' badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Build Status](https://github.com/semantic-release/github/actions/workflows/test.yml/badge.svg)](https://github.com/semantic-release/github/actions/workflows/test.yml?query=branch%3Amaster)
 
 [![npm latest version](https://img.shields.io/npm/v/@semantic-release/github/latest.svg)](https://www.npmjs.com/package/@semantic-release/github)
-[![npm next version](https://img.shields.io/npm/v/@semantic-release/github/next.svg)](https://www.npmjs.com/package/@semantic-release/github)
 [![npm beta version](https://img.shields.io/npm/v/@semantic-release/github/beta.svg)](https://www.npmjs.com/package/@semantic-release/github)
 
 | Step               | Description                                                                                                                                                                                                                              |


### PR DESCRIPTION
Removed the npm next version badge from the README.