### PR TITLE
fix: ignore cross-repository associated pull requests

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -74,6 +74,8 @@ export default async function success(pluginConfig, context, { Octokit }) {
     );
     const releaseInfos = releases.filter((release) => Boolean(release.name));
     const shas = commits.map(({ hash }) => hash);
+    const isSameRepository = ({ repository }) =>
+      !repository || repository.nameWithOwner === `${owner}/${repo}`;
 
     // Get associatedPRs
     const associatedPRs = await inChunks(shas, 100, async (chunk) => {
@@ -88,7 +90,9 @@ export default async function success(pluginConfig, context, { Octokit }) {
       for (const { nodes, pageInfo } of responseAssociatedPRs) {
         if (nodes.length === 0) continue;
 
-        responsePRs.push(...buildIssuesOrPRsFromResponseNode(nodes));
+        responsePRs.push(
+          ...buildIssuesOrPRsFromResponseNode(nodes.filter(isSameRepository)),
+        );
         if (pageInfo.hasNextPage) {
           let cursor = pageInfo.endCursor;
           let hasNextPage = true;
@@ -100,7 +104,7 @@ export default async function success(pluginConfig, context, { Octokit }) {
             const { associatedPullRequests } = repository.commit;
             responsePRs.push(
               ...buildIssuesOrPRsFromResponseNode(
-                associatedPullRequests.nodes,
+                associatedPullRequests.nodes.filter(isSameRepository),
                 "PR",
               ),
             );
@@ -467,6 +471,9 @@ function buildAssociatedPRsQuery(shas) {
                 }
                 nodes {
                   ${baseFields}
+                  repository {
+                    nameWithOwner
+                  }
                   mergeable
                   changedFiles
                   mergedAt
@@ -506,6 +513,9 @@ const loadSingleCommitAssociatedPRs = `#graphql
             }
             nodes {
               ${baseFields}
+              repository {
+                nameWithOwner
+              }
               mergeable
               changedFiles
               mergedAt

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -1306,7 +1306,7 @@ test("Do not add comment and labels for unrelated PR returned by search (compare
   t.true(fetch.done());
 });
 
-test("Do not add comment and labels if no PR is associated with release commits", async (t) => {
+test("Do not add comment and labels for PRs from another repository", async (t) => {
   const owner = "test_user";
   const repo = "test_repo";
   const env = { GITHUB_TOKEN: "github_token" };
@@ -1344,7 +1344,14 @@ test("Do not add comment and labels if no PR is associated with release commits"
                   endCursor: "NI",
                   hasNextPage: false,
                 },
-                nodes: [],
+                nodes: [
+                  {
+                    number: 1,
+                    __typename: "PullRequest",
+                    state: "closed",
+                    repository: { nameWithOwner: "other/repository" },
+                  },
+                ],
               },
             },
           },


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/sjh9714'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/sjh9714/tally.svg'></a>

## Summary

Fixes #1092.

Ignore pull requests that GitHub associates with a release commit through a different repository. This prevents an unrelated pull request number from being looked up in the release repository and failing the `success` step with a 404.

## Changes

- Include repository identity in associated pull request queries and filter cross-repository results before REST lookups
- Add regression coverage for a commit associated with a pull request from another repository

## Testing

- `node_modules/.bin/ava --verbose test/success.test.js --match='Do not add comment and labels for PRs from another repository'`
- `npm run test:unit`
- `npm test`